### PR TITLE
Implement transaction feature to track historical buy/sell events

### DIFF
--- a/frontend/vite-project/src/components/TransactionHistory.tsx
+++ b/frontend/vite-project/src/components/TransactionHistory.tsx
@@ -1,0 +1,101 @@
+import { useState, useEffect } from 'react'
+import type { Transaction } from '../types/transaction'
+import { formatDateTime } from '../utils/dateUtils'
+
+export default function TransactionHistory() {
+  const [transactions, setTransactions] = useState<Transaction[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string>('')
+
+  const fetchTransactions = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const response = await fetch('/api/portfolio/transactions', {
+        method: 'GET',
+        credentials: 'include',
+      })
+      if (!response.ok) throw new Error('Failed to fetch transactions')
+      const data = await response.json()
+      setTransactions(data)
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unexpected error'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchTransactions()
+  }, [])
+
+  if (loading) {
+    return <div style={{ color: '#6c757d' }}>Loading transactions...</div>
+  }
+
+  if (error) {
+    return <div style={{ color: '#dc3545' }}>Error: {error}</div>
+  }
+
+  if (transactions.length === 0) {
+    return <div style={{ color: '#6c757d', fontStyle: 'italic' }}>No transactions yet</div>
+  }
+
+  return (
+    <div style={{ overflowX: 'auto' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
+        <thead>
+          <tr>
+            {['Date', 'Type', 'Ticker', 'Shares', 'Price', 'Total'].map((h) => (
+              <th
+                key={h}
+                style={{
+                  border: '1px solid #ddd',
+                  padding: '8px',
+                  textAlign: 'left',
+                  background: '#808080',
+                  color: 'white',
+                  fontWeight: 'bold',
+                }}
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {transactions.map((t) => (
+            <tr key={t.id}>
+              <td style={{ border: '1px solid #ddd', padding: '8px', color: '#6c757d' }}>
+                {formatDateTime(t.timestamp)}
+              </td>
+              <td
+                style={{
+                  border: '1px solid #ddd',
+                  padding: '8px',
+                  fontWeight: 'bold',
+                  color: t.type === 'BUY' ? '#28a745' : '#dc3545',
+                }}
+              >
+                {t.type}
+              </td>
+              <td style={{ border: '1px solid #ddd', padding: '8px', color: '#6c757d' }}>
+                {t.ticker}
+              </td>
+              <td style={{ border: '1px solid #ddd', padding: '8px', color: '#6c757d' }}>
+                {t.shares}
+              </td>
+              <td style={{ border: '1px solid #ddd', padding: '8px', color: '#6c757d' }}>
+                ${t.price.toFixed(2)}
+              </td>
+              <td style={{ border: '1px solid #ddd', padding: '8px', color: '#6c757d' }}>
+                ${t.totalValue.toFixed(2)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/vite-project/src/pages/Dashboard.tsx
+++ b/frontend/vite-project/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { roundToMinute } from '../utils/dateUtils'
 import PortfolioChart from '../components/PortfolioChart'
+import TransactionHistory from '../components/TransactionHistory'
 
 type StockData = {
   stock: Stock | null
@@ -41,6 +42,10 @@ export default function Dashboard() {
   const [showAddModal, setShowAddModal] = useState(false)
   const [newTicker, setNewTicker] = useState('')
   const [newShares, setNewShares] = useState('')
+  const [showSellModal, setShowSellModal] = useState(false)
+  const [sellTicker, setSellTicker] = useState('')
+  const [sellShares, setSellShares] = useState('')
+  const [maxShares, setMaxShares] = useState(0)
   const hasFetched = useRef(false)
   
   useEffect(() => {
@@ -156,20 +161,46 @@ export default function Dashboard() {
     }
   }
 
-  const removeHolding = async (ticker: string) => {
-    if (!confirm(`Are you sure you want to sell ${ticker}?`)) return
+  const openSellModal = (ticker: string, shares: number) => {
+    setSellTicker(ticker)
+    setMaxShares(shares)
+    setSellShares('')
+    setShowSellModal(true)
+  }
+
+  const closeSellModal = () => {
+    setShowSellModal(false)
+    setSellTicker('')
+    setSellShares('')
+    setMaxShares(0)
+    setError('')
+  }
+
+  const executeSell = async () => {
+    if (!sellShares || Number(sellShares) <= 0) {
+      setError('Please enter a valid number of shares')
+      return
+    }
+    if (Number(sellShares) > maxShares) {
+      setError(`Cannot sell more than ${maxShares} shares`)
+      return
+    }
 
     setLoading(true)
     try {
-      const response = await fetch('/api/portfolio/holdings/remove', {
+      const response = await fetch('/api/portfolio/holdings/sell', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ticker }),
+        body: JSON.stringify({
+          ticker: sellTicker,
+          shares: Number(sellShares)
+        }),
         credentials: 'include',
       })
 
-      if (!response.ok) throw new Error('Failed to remove holding')
+      if (!response.ok) throw new Error('Failed to sell holding')
 
+      closeSellModal()
       await fetchPortfolioInfo()
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Unexpected error'
@@ -177,6 +208,10 @@ export default function Dashboard() {
     } finally {
       setLoading(false)
     }
+  }
+
+  const removeHolding = async (ticker: string, shares: number) => {
+    openSellModal(ticker, shares)
   }
 
   const calculatePortfolioValue = () => {
@@ -370,7 +405,7 @@ export default function Dashboard() {
 
                       <td style={{ border: '1px solid #ddd', padding: 8 }}>
                         <button
-                          onClick={() => removeHolding(r.ticker)}
+                          onClick={() => removeHolding(r.ticker, r.shares)}
                           disabled={loading}
                           style={{
                             padding: '4px 8px',
@@ -393,6 +428,12 @@ export default function Dashboard() {
           </div>
         </div>
       )}
+
+      {/* Transaction History Section */}
+      <div style={{ marginTop: 32, marginBottom: 32 }}>
+        <h3>Transaction History</h3>
+        <TransactionHistory />
+      </div>
 
       {/* Trending Stocks Section */}
       {trendingStocks.length > 0 && (
@@ -514,6 +555,63 @@ export default function Dashboard() {
                 style={{ backgroundColor: '#28a745', color: 'white' }}
               >
                 {loading ? 'Buying…' : 'Buy'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {/* Sell Stock Modal */}
+      {showSellModal && (
+        <div style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: 'rgba(0,0,0,0.5)',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          zIndex: 1000
+        }}>
+          <div style={{
+            backgroundColor: '#d3d3d3',
+            padding: 24,
+            borderRadius: 8,
+            width: '90%',
+            maxWidth: 400
+          }}>
+            <h3 style={{ marginTop: 0, color: '#494949' }}>Sell {sellTicker}</h3>
+            <div style={{ marginBottom: 16 }}>
+              <label style={{ display: 'block', marginBottom: 4, color: 'grey' }}>
+                Shares (max: {maxShares})
+              </label>
+              <input
+                type="number"
+                placeholder="Number of shares to sell"
+                value={sellShares}
+                onChange={(e) => setSellShares(e.target.value)}
+                min="0.01"
+                max={maxShares}
+                step="0.01"
+                style={{ 
+                  width: '100%', 
+                  padding: 8,
+                  boxSizing: 'border-box',
+                  fontSize: 16
+                }}
+              />
+            </div>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button onClick={closeSellModal}>
+                Cancel
+              </button>
+              <button 
+                onClick={executeSell}
+                disabled={loading || !sellShares || Number(sellShares) <= 0 || Number(sellShares) > maxShares}
+                style={{ backgroundColor: '#dc3545', color: 'white' }}
+              >
+                {loading ? 'Selling…' : 'Sell'}
               </button>
             </div>
           </div>

--- a/frontend/vite-project/src/types/transaction.ts
+++ b/frontend/vite-project/src/types/transaction.ts
@@ -1,0 +1,9 @@
+export type Transaction = {
+  id: number
+  ticker: string
+  shares: number
+  price: number
+  totalValue: number
+  type: 'BUY' | 'SELL'
+  timestamp: string
+}

--- a/frontend/vite-project/src/utils/dateUtils.ts
+++ b/frontend/vite-project/src/utils/dateUtils.ts
@@ -5,3 +5,17 @@ export const roundToMinute = (timestamp: string): string => {
     date.setSeconds(0, 0);
     return date.toLocaleTimeString("en-US", {timeZone: "America/New_York", hour: '2-digit', minute: '2-digit'});
 }
+
+// formats timestamp to date and time in EST
+export const formatDateTime = (timestamp: string): string => {
+    if(!timestamp) return '';
+    const date = new Date(timestamp);
+    return date.toLocaleString("en-US", {
+        timeZone: "America/New_York",
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+    });
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/controller/PortfolioController.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/controller/PortfolioController.java
@@ -3,8 +3,10 @@ package com.github.fabianjim.portfoliomonitor.controller;
 import com.github.fabianjim.portfoliomonitor.dto.PortfolioHistoryDTO;
 import com.github.fabianjim.portfoliomonitor.model.Holding;
 import com.github.fabianjim.portfoliomonitor.model.Portfolio;
+import com.github.fabianjim.portfoliomonitor.model.Transaction;
 import com.github.fabianjim.portfoliomonitor.model.TrackedStock;
 import com.github.fabianjim.portfoliomonitor.service.PortfolioService;
+import com.github.fabianjim.portfoliomonitor.service.TransactionService;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,9 +17,11 @@ import java.util.Map;
 public class PortfolioController {
 
     private final PortfolioService portfolioService;
+    private final TransactionService transactionService;
 
-    public PortfolioController(PortfolioService portfolioService) {
+    public PortfolioController(PortfolioService portfolioService, TransactionService transactionService) {
         this.portfolioService = portfolioService;
+        this.transactionService = transactionService;
     }
     @PostMapping
     public void submitPortfolio(@RequestBody Portfolio portfolio) {
@@ -71,6 +75,18 @@ public class PortfolioController {
     @GetMapping("/history")
     public List<PortfolioHistoryDTO> getPortfolioHistory() {
         return portfolioService.getPortfolioHistory();
+    }
+
+    @GetMapping("/transactions")
+    public List<Transaction> getTransactionHistory() {
+        return transactionService.getTransactionHistory();
+    }
+
+    @PostMapping("/holdings/sell")
+    public void sellHolding(@RequestBody Map<String, Object> request) {
+        String ticker = (String) request.get("ticker");
+        double shares = ((Number) request.get("shares")).doubleValue();
+        portfolioService.sellHolding(ticker, shares);
     }
 
 }

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/model/Transaction.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/model/Transaction.java
@@ -1,0 +1,123 @@
+package com.github.fabianjim.portfoliomonitor.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "transactions")
+public class Transaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false)
+    private String ticker;
+
+    @Column(nullable = false)
+    private double shares;
+
+    @Column(nullable = false)
+    private double price;
+
+    @Column(name = "total_value", nullable = false)
+    private double totalValue;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TransactionType type;
+
+    @Column(nullable = false)
+    private Instant timestamp;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public enum TransactionType {
+        BUY,
+        SELL
+    }
+
+    public Transaction() {}
+
+    public Transaction(String ticker, double shares, double price, TransactionType type) {
+        this.ticker = ticker;
+        this.shares = shares;
+        this.price = price;
+        this.totalValue = shares * price;
+        this.type = type;
+        this.timestamp = Instant.now();
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (this.timestamp == null) {
+            this.timestamp = Instant.now();
+        }
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getTicker() {
+        return ticker;
+    }
+
+    public void setTicker(String ticker) {
+        this.ticker = ticker;
+    }
+
+    public double getShares() {
+        return shares;
+    }
+
+    public void setShares(double shares) {
+        this.shares = shares;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public void setPrice(double price) {
+        this.price = price;
+    }
+
+    public double getTotalValue() {
+        return totalValue;
+    }
+
+    public void setTotalValue(double totalValue) {
+        this.totalValue = totalValue;
+    }
+
+    public TransactionType getType() {
+        return type;
+    }
+
+    public void setType(TransactionType type) {
+        this.type = type;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/repository/TransactionRepository.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/repository/TransactionRepository.java
@@ -1,0 +1,15 @@
+package com.github.fabianjim.portfoliomonitor.repository;
+
+import com.github.fabianjim.portfoliomonitor.model.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TransactionRepository extends JpaRepository<Transaction, Integer> {
+    
+    List<Transaction> findByUserIdOrderByTimestampDesc(int userId);
+    
+    List<Transaction> findByUserIdAndTicker(int userId, String ticker);
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/service/PortfolioService.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/service/PortfolioService.java
@@ -32,17 +32,20 @@ public class PortfolioService {
     private final UserRepository userRepository;
     private final TrackedStockRepository trackedStockRepository;
     private final StockRepository stockRepository;
+    private final TransactionService transactionService;
 
     public PortfolioService(PortfolioRepository portfolioRepository,
                           StockService stockService,
                           UserRepository userRepository,
                           TrackedStockRepository trackedStockRepository,
-                          StockRepository stockRepository) {
+                          StockRepository stockRepository,
+                          TransactionService transactionService) {
         this.portfolioRepository = portfolioRepository;
         this.stockService = stockService;
         this.userRepository = userRepository;
         this.trackedStockRepository = trackedStockRepository;
         this.stockRepository = stockRepository;
+        this.transactionService = transactionService;
     }
 
     private Integer getCurrentUserId() {
@@ -115,6 +118,11 @@ public class PortfolioService {
             throw new RuntimeException("No portfolio found for current user");
         }
 
+        // Get current price for transaction
+        double currentPrice = stockService.getLatestStockData(ticker)
+            .map(Stock::getCurrentPrice)
+            .orElse(0.0);
+
         Holding newHolding = new Holding(ticker, shares);
         portfolio.getHoldings().add(newHolding);
         portfolioRepository.save(portfolio);
@@ -122,6 +130,9 @@ public class PortfolioService {
         // Start tracking and fetch initial data
         startTrackingStock(ticker);
         stockService.updateStockData(ticker, Stock.StockType.INITIAL);
+
+        // Record buy transaction
+        transactionService.recordBuyTransaction(ticker, shares, currentPrice);
     }
 
     /**
@@ -133,11 +144,65 @@ public class PortfolioService {
             throw new RuntimeException("No portfolio found for current user");
         }
 
+        // Get shares and current price for transaction before removing
+        double shares = portfolio.getHoldings().stream()
+            .filter(h -> h.getTicker().equals(ticker))
+            .findFirst()
+            .map(Holding::getShares)
+            .orElse(0.0);
+        
+        double currentPrice = stockService.getLatestStockData(ticker)
+            .map(Stock::getCurrentPrice)
+            .orElse(0.0);
+
         portfolio.getHoldings().removeIf(h -> h.getTicker().equals(ticker));
         portfolioRepository.save(portfolio);
 
         // Stop tracking this stock
         stopTrackingStock(ticker);
+
+        // Record sell transaction
+        if (shares > 0) {
+            transactionService.recordSellTransaction(ticker, shares, currentPrice);
+        }
+    }
+
+    /**
+     * Sell a portion of a holding (partial sell).
+     */
+    public void sellHolding(String ticker, double sharesToSell) {
+        Portfolio portfolio = getPortfolio();
+        if (portfolio == null) {
+            throw new RuntimeException("No portfolio found for current user");
+        }
+
+        Holding holding = portfolio.getHoldings().stream()
+            .filter(h -> h.getTicker().equals(ticker))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("Holding not found for ticker: " + ticker));
+
+        if (sharesToSell > holding.getShares()) {
+            throw new RuntimeException("Cannot sell more shares than owned");
+        }
+
+        double currentPrice = stockService.getLatestStockData(ticker)
+            .map(Stock::getCurrentPrice)
+            .orElse(0.0);
+
+        // Record sell transaction
+        transactionService.recordSellTransaction(ticker, sharesToSell, currentPrice);
+
+        // Update or remove holding
+        if (sharesToSell == holding.getShares()) {
+            // Selling all shares - remove the holding
+            portfolio.getHoldings().removeIf(h -> h.getTicker().equals(ticker));
+            stopTrackingStock(ticker);
+        } else {
+            // Partial sell - update shares
+            holding.setShares(holding.getShares() - sharesToSell);
+        }
+
+        portfolioRepository.save(portfolio);
     }
 
     public List<String> getTickersfromPortfolio(Portfolio portfolio) {

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/service/TransactionService.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/service/TransactionService.java
@@ -1,0 +1,73 @@
+package com.github.fabianjim.portfoliomonitor.service;
+
+import com.github.fabianjim.portfoliomonitor.model.Transaction;
+import com.github.fabianjim.portfoliomonitor.model.Transaction.TransactionType;
+import com.github.fabianjim.portfoliomonitor.model.User;
+import com.github.fabianjim.portfoliomonitor.repository.TransactionRepository;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class TransactionService {
+
+    private final TransactionRepository transactionRepository;
+
+    public TransactionService(TransactionRepository transactionRepository) {
+        this.transactionRepository = transactionRepository;
+    }
+
+    private Integer getCurrentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null) {
+            throw new RuntimeException("No authenticated user found");
+        }
+        User user = (User) auth.getPrincipal();
+        return user.getId();
+    }
+
+    private User getCurrentUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null) {
+            throw new RuntimeException("No authenticated user found");
+        }
+        return (User) auth.getPrincipal();
+    }
+
+    /**
+     * Record a buy transaction
+     */
+    public Transaction recordBuyTransaction(String ticker, double shares, double price) {
+        Transaction transaction = new Transaction(ticker, shares, price, TransactionType.BUY);
+        transaction.setUser(getCurrentUser());
+        return transactionRepository.save(transaction);
+    }
+
+    /**
+     * Record a sell transaction
+     */
+    public Transaction recordSellTransaction(String ticker, double shares, double price) {
+        Transaction transaction = new Transaction(ticker, shares, price, TransactionType.SELL);
+        transaction.setUser(getCurrentUser());
+        return transactionRepository.save(transaction);
+    }
+
+    /**
+     * Get transaction history for current user
+     */
+    public List<Transaction> getTransactionHistory() {
+        return transactionRepository.findByUserIdOrderByTimestampDesc(getCurrentUserId());
+    }
+
+    /**
+     * Get transaction history for current user and specific ticker
+     */
+    public List<Transaction> getTransactionHistoryForTicker(String ticker) {
+        return transactionRepository.findByUserIdAndTicker(getCurrentUserId(), ticker);
+    }
+}

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/model/TransactionTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/model/TransactionTest.java
@@ -1,0 +1,87 @@
+package com.github.fabianjim.portfoliomonitor.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TransactionTest {
+
+    @Test
+    void createTransactionWithAllFields() {
+        // Given
+        Instant now = Instant.now();
+        String ticker = "AAPL";
+        double shares = 10.0;
+        double price = 150.0;
+        double totalValue = 1500.0;
+        Transaction.TransactionType type = Transaction.TransactionType.BUY;
+        
+        // When
+        Transaction transaction = new Transaction();
+        transaction.setTicker(ticker);
+        transaction.setShares(shares);
+        transaction.setPrice(price);
+        transaction.setTotalValue(totalValue);
+        transaction.setType(type);
+        transaction.setTimestamp(now);
+        
+        // Then
+        assertEquals(ticker, transaction.getTicker());
+        assertEquals(shares, transaction.getShares(), 0.01);
+        assertEquals(price, transaction.getPrice(), 0.01);
+        assertEquals(totalValue, transaction.getTotalValue(), 0.01);
+        assertEquals(type, transaction.getType());
+        assertEquals(now, transaction.getTimestamp());
+    }
+
+    @Test
+    void transactionTypeEnumHasBuyAndSell() {
+        // Given/When/Then
+        assertNotNull(Transaction.TransactionType.BUY);
+        assertNotNull(Transaction.TransactionType.SELL);
+        assertEquals(2, Transaction.TransactionType.values().length);
+    }
+
+    @Test
+    void transactionPrePersistSetsTimestamp() {
+        // Given
+        Transaction transaction = new Transaction();
+        transaction.setTicker("GOOGL");
+        transaction.setShares(5.0);
+        transaction.setPrice(200.0);
+        transaction.setTotalValue(1000.0);
+        transaction.setType(Transaction.TransactionType.BUY);
+        
+        // When
+        Instant beforePersist = Instant.now();
+        transaction.prePersist();
+        Instant afterPersist = Instant.now();
+        
+        // Then
+        assertNotNull(transaction.getTimestamp());
+        assertTrue(!transaction.getTimestamp().isBefore(beforePersist));
+        assertTrue(!transaction.getTimestamp().isAfter(afterPersist));
+    }
+
+    @Test
+    void createTransactionWithConvenienceConstructor() {
+        // Given
+        String ticker = "MSFT";
+        double shares = 20.0;
+        double price = 300.0;
+        Transaction.TransactionType type = Transaction.TransactionType.SELL;
+        
+        // When
+        Transaction transaction = new Transaction(ticker, shares, price, type);
+        
+        // Then
+        assertEquals(ticker, transaction.getTicker());
+        assertEquals(shares, transaction.getShares(), 0.01);
+        assertEquals(price, transaction.getPrice(), 0.01);
+        assertEquals(shares * price, transaction.getTotalValue(), 0.01);
+        assertEquals(type, transaction.getType());
+        assertNotNull(transaction.getTimestamp());
+    }
+}

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/repository/TransactionRepositoryTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/repository/TransactionRepositoryTest.java
@@ -1,0 +1,103 @@
+package com.github.fabianjim.portfoliomonitor.repository;
+
+import com.github.fabianjim.portfoliomonitor.model.Transaction;
+import com.github.fabianjim.portfoliomonitor.model.Transaction.TransactionType;
+import com.github.fabianjim.portfoliomonitor.model.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class TransactionRepositoryTest {
+
+    @Autowired
+    private TransactionRepository transactionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void testSaveAndFindTransaction() {
+        // Create a user first
+        User user = new User();
+        user.setUsername("testuser");
+        user.setPassword("password");
+        user = userRepository.save(user);
+
+        // Create a transaction
+        Transaction transaction = new Transaction("AAPL", 10.0, 150.0, TransactionType.BUY);
+        transaction.setUser(user);
+        
+        // Save the transaction
+        Transaction savedTransaction = transactionRepository.save(transaction);
+        
+        // Verify it was saved with an ID
+        assertNotNull(savedTransaction.getId());
+        assertEquals("AAPL", savedTransaction.getTicker());
+        assertEquals(10.0, savedTransaction.getShares(), 0.01);
+        assertEquals(150.0, savedTransaction.getPrice(), 0.01);
+        assertEquals(1500.0, savedTransaction.getTotalValue(), 0.01);
+        assertEquals(TransactionType.BUY, savedTransaction.getType());
+        assertNotNull(savedTransaction.getTimestamp());
+    }
+
+    @Test
+    void testFindByUserIdOrderByTimestampDesc() {
+        // Create a user
+        User user = new User();
+        user.setUsername("testuser2");
+        user.setPassword("password");
+        user = userRepository.save(user);
+
+        // Create transactions at different times
+        Transaction transaction1 = new Transaction("AAPL", 10.0, 150.0, TransactionType.BUY);
+        transaction1.setUser(user);
+        transaction1.setTimestamp(Instant.now().minusSeconds(3600)); // 1 hour ago
+        transactionRepository.save(transaction1);
+
+        Transaction transaction2 = new Transaction("GOOGL", 5.0, 200.0, TransactionType.BUY);
+        transaction2.setUser(user);
+        transaction2.setTimestamp(Instant.now()); // Now
+        transactionRepository.save(transaction2);
+
+        // Find by user ID ordered by timestamp desc
+        List<Transaction> transactions = transactionRepository.findByUserIdOrderByTimestampDesc(user.getId());
+        
+        // Verify results
+        assertEquals(2, transactions.size());
+        assertEquals("GOOGL", transactions.get(0).getTicker()); // Most recent first
+        assertEquals("AAPL", transactions.get(1).getTicker()); // Oldest last
+    }
+
+    @Test
+    void testFindByUserIdAndTicker() {
+        // Create a user
+        User user = new User();
+        user.setUsername("testuser3");
+        user.setPassword("password");
+        user = userRepository.save(user);
+
+        // Create transactions for different tickers
+        Transaction aaplTransaction = new Transaction("AAPL", 10.0, 150.0, TransactionType.BUY);
+        aaplTransaction.setUser(user);
+        transactionRepository.save(aaplTransaction);
+
+        Transaction googlTransaction = new Transaction("GOOGL", 5.0, 200.0, TransactionType.BUY);
+        googlTransaction.setUser(user);
+        transactionRepository.save(googlTransaction);
+
+        // Find by user ID and ticker
+        List<Transaction> aaplTransactions = transactionRepository.findByUserIdAndTicker(user.getId(), "AAPL");
+        
+        // Verify results
+        assertEquals(1, aaplTransactions.size());
+        assertEquals("AAPL", aaplTransactions.get(0).getTicker());
+    }
+}

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/service/PortfolioServiceTransactionTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/service/PortfolioServiceTransactionTest.java
@@ -1,0 +1,136 @@
+package com.github.fabianjim.portfoliomonitor.service;
+
+import com.github.fabianjim.portfoliomonitor.model.Holding;
+import com.github.fabianjim.portfoliomonitor.model.Portfolio;
+import com.github.fabianjim.portfoliomonitor.model.Stock;
+import com.github.fabianjim.portfoliomonitor.model.Transaction;
+import com.github.fabianjim.portfoliomonitor.model.Transaction.TransactionType;
+import com.github.fabianjim.portfoliomonitor.model.User;
+import com.github.fabianjim.portfoliomonitor.repository.PortfolioRepository;
+import com.github.fabianjim.portfoliomonitor.repository.StockRepository;
+import com.github.fabianjim.portfoliomonitor.repository.TrackedStockRepository;
+import com.github.fabianjim.portfoliomonitor.repository.UserRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PortfolioServiceTransactionTest {
+
+    @Mock
+    private PortfolioRepository portfolioRepository;
+
+    @Mock
+    private StockRepository stockRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TrackedStockRepository trackedStockRepository;
+
+    @Mock
+    private StockService stockService;
+
+    @Mock
+    private TransactionService transactionService;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private Authentication authentication;
+
+    @InjectMocks
+    private PortfolioService portfolioService;
+
+    private User mockUser;
+    private Portfolio mockPortfolio;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = new User();
+        mockUser.setId(1);
+        mockUser.setUsername("testuser");
+
+        mockPortfolio = new Portfolio();
+        mockPortfolio.setId(1);
+        mockPortfolio.setUser(mockUser);
+        mockPortfolio.setHoldings(new ArrayList<>());
+
+        SecurityContextHolder.setContext(securityContext);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(mockUser);
+    }
+
+    @Test
+    void addHoldingRecordsBuyTransaction() {
+        // Given
+        String ticker = "AAPL";
+        double shares = 10.0;
+        double currentPrice = 150.0;
+
+        when(portfolioRepository.findByUserId(1)).thenReturn(Optional.of(mockPortfolio));
+        when(stockService.getLatestStockData(ticker)).thenReturn(Optional.of(createStock(ticker, currentPrice)));
+        when(portfolioRepository.save(any(Portfolio.class))).thenReturn(mockPortfolio);
+        when(transactionService.recordBuyTransaction(eq(ticker), eq(shares), eq(currentPrice)))
+            .thenReturn(createTransaction(ticker, shares, currentPrice, TransactionType.BUY));
+
+        // When
+        portfolioService.addHolding(ticker, shares);
+
+        // Then
+        verify(transactionService).recordBuyTransaction(ticker, shares, currentPrice);
+    }
+
+    @Test
+    void removeHoldingRecordsSellTransaction() {
+        // Given
+        String ticker = "GOOGL";
+        double shares = 5.0;
+        double currentPrice = 200.0;
+
+        Holding holding = new Holding(ticker, shares);
+        mockPortfolio.getHoldings().add(holding);
+
+        when(portfolioRepository.findByUserId(1)).thenReturn(Optional.of(mockPortfolio));
+        when(stockService.getLatestStockData(ticker)).thenReturn(Optional.of(createStock(ticker, currentPrice)));
+        when(transactionService.recordSellTransaction(eq(ticker), eq(shares), eq(currentPrice)))
+            .thenReturn(createTransaction(ticker, shares, currentPrice, TransactionType.SELL));
+
+        // When
+        portfolioService.removeHolding(ticker);
+
+        // Then
+        verify(transactionService).recordSellTransaction(ticker, shares, currentPrice);
+    }
+
+    private Stock createStock(String ticker, double price) {
+        Stock stock = new Stock();
+        stock.setTicker(ticker);
+        stock.setCurrentPrice(price);
+        return stock;
+    }
+
+    private Transaction createTransaction(String ticker, double shares, double price, TransactionType type) {
+        Transaction transaction = new Transaction(ticker, shares, price, type);
+        transaction.setId(1);
+        return transaction;
+    }
+}

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/service/TransactionServiceTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/service/TransactionServiceTest.java
@@ -1,0 +1,175 @@
+package com.github.fabianjim.portfoliomonitor.service;
+
+import com.github.fabianjim.portfoliomonitor.model.Transaction;
+import com.github.fabianjim.portfoliomonitor.model.Transaction.TransactionType;
+import com.github.fabianjim.portfoliomonitor.model.User;
+import com.github.fabianjim.portfoliomonitor.repository.TransactionRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class TransactionServiceTest {
+
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private Authentication authentication;
+
+    @InjectMocks
+    private TransactionService transactionService;
+
+    private User mockUser;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = new User();
+        mockUser.setId(1);
+        mockUser.setUsername("testuser");
+
+        SecurityContextHolder.setContext(securityContext);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(mockUser);
+    }
+
+    @Test
+    void recordBuyTransaction() {
+        // Given
+        String ticker = "AAPL";
+        double shares = 10.0;
+        double price = 150.0;
+
+        when(transactionRepository.save(any(Transaction.class))).thenAnswer(invocation -> {
+            Transaction t = invocation.getArgument(0);
+            t.setId(1);
+            return t;
+        });
+
+        // When
+        Transaction result = transactionService.recordBuyTransaction(ticker, shares, price);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(ticker, result.getTicker());
+        assertEquals(shares, result.getShares(), 0.01);
+        assertEquals(price, result.getPrice(), 0.01);
+        assertEquals(shares * price, result.getTotalValue(), 0.01);
+        assertEquals(TransactionType.BUY, result.getType());
+        assertEquals(mockUser, result.getUser());
+        assertNotNull(result.getTimestamp());
+
+        // Verify save was called
+        ArgumentCaptor<Transaction> captor = ArgumentCaptor.forClass(Transaction.class);
+        verify(transactionRepository).save(captor.capture());
+        Transaction savedTransaction = captor.getValue();
+        assertEquals(TransactionType.BUY, savedTransaction.getType());
+    }
+
+    @Test
+    void recordSellTransaction() {
+        // Given
+        String ticker = "GOOGL";
+        double shares = 5.0;
+        double price = 200.0;
+
+        when(transactionRepository.save(any(Transaction.class))).thenAnswer(invocation -> {
+            Transaction t = invocation.getArgument(0);
+            t.setId(2);
+            return t;
+        });
+
+        // When
+        Transaction result = transactionService.recordSellTransaction(ticker, shares, price);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(ticker, result.getTicker());
+        assertEquals(shares, result.getShares(), 0.01);
+        assertEquals(price, result.getPrice(), 0.01);
+        assertEquals(shares * price, result.getTotalValue(), 0.01);
+        assertEquals(TransactionType.SELL, result.getType());
+        assertEquals(mockUser, result.getUser());
+        assertNotNull(result.getTimestamp());
+
+        // Verify save was called
+        ArgumentCaptor<Transaction> captor = ArgumentCaptor.forClass(Transaction.class);
+        verify(transactionRepository).save(captor.capture());
+        Transaction savedTransaction = captor.getValue();
+        assertEquals(TransactionType.SELL, savedTransaction.getType());
+    }
+
+    @Test
+    void getTransactionHistoryForCurrentUser() {
+        // Given
+        Transaction transaction1 = new Transaction("AAPL", 10.0, 150.0, TransactionType.BUY);
+        Transaction transaction2 = new Transaction("GOOGL", 5.0, 200.0, TransactionType.BUY);
+        List<Transaction> mockTransactions = List.of(transaction1, transaction2);
+
+        when(transactionRepository.findByUserIdOrderByTimestampDesc(mockUser.getId()))
+            .thenReturn(mockTransactions);
+
+        // When
+        List<Transaction> result = transactionService.getTransactionHistory();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("AAPL", result.get(0).getTicker());
+        assertEquals("GOOGL", result.get(1).getTicker());
+        verify(transactionRepository).findByUserIdOrderByTimestampDesc(mockUser.getId());
+    }
+
+    @Test
+    void getTransactionHistoryForSpecificTicker() {
+        // Given
+        String ticker = "AAPL";
+        Transaction transaction = new Transaction(ticker, 10.0, 150.0, TransactionType.BUY);
+        List<Transaction> mockTransactions = List.of(transaction);
+
+        when(transactionRepository.findByUserIdAndTicker(mockUser.getId(), ticker))
+            .thenReturn(mockTransactions);
+
+        // When
+        List<Transaction> result = transactionService.getTransactionHistoryForTicker(ticker);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(ticker, result.get(0).getTicker());
+        verify(transactionRepository).findByUserIdAndTicker(mockUser.getId(), ticker);
+    }
+
+    @Test
+    void getTransactionHistoryEmptyList() {
+        // Given
+        when(transactionRepository.findByUserIdOrderByTimestampDesc(mockUser.getId()))
+            .thenReturn(List.of());
+
+        // When
+        List<Transaction> result = transactionService.getTransactionHistory();
+
+        // Then
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
- User initiated buy and sells from the dashboard are recorded in a separate table beneath their detailed holdings
- Transactions are recorded in a new entity on the database. Migrated rows given BUY attribute, all sells were dropped
- Transaction attributes lossless from api call for future implementation of user-made entries based on these transactions events