### PR TITLE
Add landing page with demo user session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,17 @@ frontend/vite-project/src/
 - **Non-initial transactions**: Regular `BUY`/`SELL` operations via `addHolding()`, `sellHolding()`, etc. (`isInitial=false`)
 - The frontend (`processHourlyData` in `chartData.ts`) filters out `initial=true` transactions so they are **not rendered as buy/sell event pins** on the portfolio performance graph
 
+### Demo Mode
+- A user with `is_demo = true` (set manually in the `users` table) operates entirely from a session-only snapshot after login.
+- On login, `LoginController` snapshots the demo user's real DB portfolio, transactions, journal entries, and watchlist into a `DemoSession` stored in the servlet `HttpSession` under `DEMO_SESSION`.
+- All write endpoints route to `DemoSessionService` instead of the regular services, so buys, sells, journal edits, and watchlist changes exist only in memory for that session.
+- **Trade limit**: Demo users are limited to **3 total buy/sell actions** per session. `DemoTradeLimitExceededException` is mapped to HTTP 403 by `GlobalExceptionHandler`.
+- Price fetches in demo mode use `StockService` (may insert global `Stock` price rows) but **do not modify `TrackedStock.holderCount`** or the scheduler's ticker list.
+- Logout invalidates the session and discards all demo changes; the DB demo user is untouched.
+- Frontend: `Layout.tsx` fetches `/api/auth/me` to detect demo users and displays a top banner with remaining trades via `/api/portfolio/demo-status`. `Dashboard.tsx` consumes the demo context and shows the trade-limit error in buy/sell modals.
+- New backend files: `model/DemoSession.java`, `service/DemoSessionService.java`, `service/DemoSessionResolver.java`, `exception/DemoTradeLimitExceededException.java`.
+- New endpoints: `GET /api/auth/me`, `GET /api/portfolio/demo-status`.
+
 ---
 
 ## Scheduling
@@ -251,9 +262,13 @@ npm run lint
 | `.github/workflows/aws.yml` | CI/CD for backend |
 | `src/main/java/.../exception/UnknownTickerException.java` | Thrown when a ticker symbol does not exist |
 | `src/main/java/.../exception/PriceFetchException.java` | Thrown on transient API fetch failures |
-| `src/main/java/.../controller/GlobalExceptionHandler.java` | Maps custom exceptions to HTTP 404/503 responses |
+| `src/main/java/.../exception/DemoTradeLimitExceededException.java` | Thrown when a demo user exceeds 3 buy/sell actions |
+| `src/main/java/.../controller/GlobalExceptionHandler.java` | Maps custom exceptions to HTTP 404/503/403 responses |
 | `src/main/java/.../dto/PnLSummaryDTO.java` | P/L summary data transfer object |
 | `src/main/java/.../service/PortfolioService.java` | Business logic incl. P/L calculation |
+| `src/main/java/.../service/DemoSessionService.java` | Session-only business logic for demo users |
+| `src/main/java/.../service/DemoSessionResolver.java` | Resolves demo state from the servlet session and current user |
+| `src/main/java/.../model/DemoSession.java` | In-memory session snapshot for demo users |
 | `src/main/java/.../service/EtfMetadataService.java` | ETF metadata loader (ETFs.csv → StockMetadata) |
 | `src/main/java/.../service/NasdaqMetadataService.java` | Stock metadata loader with ETF fallback |
 | `src/main/resources/data/ETFs.csv` | ETF metadata source (~1021 rows) |
@@ -262,6 +277,7 @@ npm run lint
 | `src/main/java/.../api/TiingoClient.java` | Tiingo API client; `INITIAL` stock data uses exact timestamp (not rounded) for graph accuracy |
 | `frontend/.../components/PortfolioChart.tsx` | Exposes `PortfolioChartHandle` with `refresh()` via ref |
 | `frontend/.../components/NextUpdateTimer.tsx` | Dashboard header pill showing countdown to next scheduled price fetch |
+| `frontend/.../components/Layout.tsx` | Sidebar layout; fetches `/api/auth/me` and shows demo mode banner |
 | `frontend/.../hooks/useNextUpdate.ts` | Hook computing next market update; updates every minute synced to wall clock |
 | `frontend/.../components/JournalPanel.tsx` | Exposes `JournalPanelHandle` with `scrollToEntry()` and `refreshEntries()` via ref; supports inline edit and delete with hover actions |
 | `frontend/.../components/HoldingGraph.tsx` | D3 force graph for the Analysis page; tuned for subtle, user-controlled motion with weak attraction/repulsion and alpha-decayed sector grouping |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,12 +41,14 @@ Entry point: PortfolioMonitorApplication.java (has @EnableScheduling)
 ### Frontend (React + Vite)
 ```
 frontend/vite-project/src/
-├── pages/           # Route components: Login.tsx, Dashboard.tsx, Portfolio.tsx, Analysis.tsx
+├── pages/           # Route components: Landing.tsx, Login.tsx, Dashboard.tsx, Portfolio.tsx, Analysis.tsx
 ├── components/      # UI components: PortfolioChart, WatchlistPanel, JournalPanel,
 │                    #   TransactionHistory, HoldingGraph, ChartPinLayer, etc.
+│                    #   Landing components live in components/landing/ (lightweight, static previews)
 ├── services/        # API layer (api.ts) — all backend calls go through here
 ├── types/           # TypeScript interfaces (transaction.ts, watchlist.ts, journal.ts)
-├── utils/           # Helper functions (dateUtils.ts, chartPins.ts)
+├── utils/           # Helper functions (dateUtils.ts, chartPins.ts, redirectAfterLogin.ts)
+├── hooks/           # Shared hooks: useScrollReveal.ts
 └── index.css        # Global styles + custom font declarations
 ```
 
@@ -155,6 +157,7 @@ frontend/vite-project/src/
 - Price fetches in demo mode use `StockService` (may insert global `Stock` price rows) but **do not modify `TrackedStock.holderCount`** or the scheduler's ticker list.
 - Logout invalidates the session and discards all demo changes; the DB demo user is untouched.
 - Frontend: `Layout.tsx` fetches `/api/auth/me` to detect demo users and displays a top banner with remaining trades via `/api/portfolio/demo-status`. `Dashboard.tsx` consumes the demo context and shows the trade-limit error in buy/sell modals.
+- **Landing page demo CTA**: `Landing.tsx` exposes a "Try Demo Now" button in the top nav and final section that calls `authApi.login('demo', 'demo')` and redirects to `/dashboard` (or `/portfolio` if no portfolio exists) via `redirectAfterLogin()`.
 - New backend files: `model/DemoSession.java`, `service/DemoSessionService.java`, `service/DemoSessionResolver.java`, `exception/DemoTradeLimitExceededException.java`.
 - New endpoints: `GET /api/auth/me`, `GET /api/portfolio/demo-status`.
 
@@ -292,8 +295,15 @@ npm run lint
 | `frontend/.../hooks/useNextUpdate.ts` | Hook computing next market update; updates every minute synced to wall clock |
 | `frontend/.../components/JournalPanel.tsx` | Exposes `JournalPanelHandle` with `scrollToEntry()` and `refreshEntries()` via ref; supports inline edit and delete with hover actions |
 | `frontend/.../components/HoldingGraph.tsx` | D3 force graph for the Analysis page; tuned for subtle, user-controlled motion with weak attraction/repulsion and alpha-decayed sector grouping |
-| `frontend/.../utils/dateUtils.ts` | Date helpers incl. `getNextMarketUpdate` and `formatNextUpdate` for the next-update timer |
-| `frontend/.../utils/chartData.ts` | Processes portfolio history + transactions into chart data; filters out `initial` transactions |
+| `frontend/.../pages/Landing.tsx` | Public landing page with use-case flow (Track/Reflect/Analyze/Improve), inline auth modal, and demo CTA |
+| `frontend/.../components/landing/LandingChart.tsx` | Simplified static chart for the Track section |
+| `frontend/.../components/landing/LandingJournalCard.tsx` | Simplified journal entry card for the Reflect section |
+| `frontend/.../components/landing/LandingDetailCard.tsx` | Simplified detail/analysis card for the Analyze section |
+| `frontend/.../components/landing/LandingCTA.tsx` | Final Improve section call-to-action |
+| `frontend/.../components/landing/LandingNav.tsx` | Landing top nav with Sign in button linking to `/login` |
+| `frontend/.../components/landing/LandingCTA.tsx` | Final Improve section call-to-action |
+| `frontend/.../utils/redirectAfterLogin.ts` | Redirects to `/dashboard` or `/portfolio` based on `portfolioApi.portfolioExists()` |
+| `frontend/.../hooks/useScrollReveal.ts` | IntersectionObserver hook for landing section fade/slide transitions |
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,15 +22,16 @@ Core philosophy:
 src/main/java/com/github/fabianjim/portfoliomonitor/
 ├── api/              # External API clients (TiingoClient, MarketDataClient)
 ├── config/           # TestSchedulingConfig (profile-gated scheduling)
-├── controller/       # REST endpoints (Portfolio, Auth, Stock, Watchlist, JournalEntry, Login)
+├── controller/       # REST endpoints (Portfolio, Auth, Stock, Watchlist, JournalEntry, Login, Events)
 │   └── GlobalExceptionHandler.java  # @ControllerAdvice — maps exceptions to HTTP responses
 ├── dto/              # Data transfer objects
+├── event/            # Spring application events + SSE broadcasting for hourly price fetches
 ├── exception/        # Custom exceptions: UnknownTickerException, PriceFetchException
 ├── model/            # JPA entities
 ├── repository/       # Spring Data JPA repositories
 ├── security/         # SecurityConfig (CORS, BCryptPasswordEncoder, session-based auth)
 └── service/          # Business logic (PortfolioService, StockService, TransactionService, etc.)
-    ├── ScheduledStockService.java   # Cron jobs: intraday (10AM-4PM EST) + EOD (4:30PM EST)
+    ├── ScheduledStockService.java   # Cron jobs: intraday (10AM-4PM EST) + EOD (4:30PM EST); publishes fetch-complete events
     ├── NasdaqMetadataService.java   # Loads nasdaq_metadata.csv; falls back to EtfMetadataService
     └── EtfMetadataService.java      # Loads ETFs.csv with Asset→sector, Category→industry, Region→country mapping
 
@@ -71,6 +72,13 @@ frontend/vite-project/src/
 - Holdings table with ticker, shares, current price, day change, market value, last updated
 - Buy and sell stock actions
 - Chart pin layer: journal entries rendered as typed pins directly on the performance chart. Pin color reflects outcome retroactively (green/red based on price movement after entry).
+- **Auto-refresh on hourly fetch**: The dashboard opens an SSE stream to `GET /api/events`. When the backend completes a scheduled hourly price fetch, it broadcasts a `priceFetchCompleted` event; the dashboard then refreshes holdings, P/L summary, and the portfolio chart automatically.
+
+### Server-Sent Events (SSE)
+- `ScheduledStockService` publishes a `PriceFetchCompletedEvent` after each intraday and EOD fetch completes.
+- `PriceFetchEventService` maintains active `SseEmitter` subscriptions and broadcasts `priceFetchCompleted` events to all connected clients.
+- `EventController` exposes the authenticated endpoint `GET /api/events` for the frontend to subscribe.
+- The frontend subscribes with `EventSource('/api/events', { withCredentials: true })` in `Dashboard.tsx` and triggers the same refresh functions used after manual buy/sell flows.
 
 ### Portfolio History Calculation
 - `PortfolioService.getPortfolioHistory()` groups stock data by `hourBucket` and calculates portfolio value at each bucket
@@ -263,6 +271,9 @@ npm run lint
 | `src/main/java/.../exception/UnknownTickerException.java` | Thrown when a ticker symbol does not exist |
 | `src/main/java/.../exception/PriceFetchException.java` | Thrown on transient API fetch failures |
 | `src/main/java/.../exception/DemoTradeLimitExceededException.java` | Thrown when a demo user exceeds 3 buy/sell actions |
+| `src/main/java/.../event/PriceFetchCompletedEvent.java` | Spring application event signaling an hourly price fetch completed |
+| `src/main/java/.../event/PriceFetchEventService.java` | Manages `SseEmitter` subscriptions and broadcasts fetch-completed events |
+| `src/main/java/.../controller/EventController.java` | Authenticated `GET /api/events` SSE endpoint |
 | `src/main/java/.../controller/GlobalExceptionHandler.java` | Maps custom exceptions to HTTP 404/503/403 responses |
 | `src/main/java/.../dto/PnLSummaryDTO.java` | P/L summary data transfer object |
 | `src/main/java/.../service/PortfolioService.java` | Business logic incl. P/L calculation |
@@ -275,7 +286,7 @@ npm run lint
 | `src/main/resources/data/nasdaq_metadata.csv` | Stock metadata source (~6996 rows) |
 | `src/main/java/.../model/Transaction.java` | Transaction entity with `isInitial` flag distinguishing portfolio creation from buys |
 | `src/main/java/.../api/TiingoClient.java` | Tiingo API client; `INITIAL` stock data uses exact timestamp (not rounded) for graph accuracy |
-| `frontend/.../components/PortfolioChart.tsx` | Exposes `PortfolioChartHandle` with `refresh()` via ref |
+| `frontend/.../components/PortfolioChart.tsx` | Exposes `PortfolioChartHandle` with `refresh()` via ref; chart refreshes on SSE `priceFetchCompleted` events |
 | `frontend/.../components/NextUpdateTimer.tsx` | Dashboard header pill showing countdown to next scheduled price fetch |
 | `frontend/.../components/Layout.tsx` | Sidebar layout; fetches `/api/auth/me` and shows demo mode banner |
 | `frontend/.../hooks/useNextUpdate.ts` | Hook computing next market update; updates every minute synced to wall clock |

--- a/frontend/vite-project/src/App.tsx
+++ b/frontend/vite-project/src/App.tsx
@@ -1,8 +1,9 @@
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import './App.css'
 import Layout from './components/Layout'
 import Portfolio from './pages/Portfolio'
 import Login from './pages/Login'
+import Landing from './pages/Landing'
 import Dashboard from './pages/Dashboard'
 import Analysis from './pages/Analysis'
 import Transactions from './pages/Transactions'
@@ -15,7 +16,7 @@ export default function App() {
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/portfolio" element={<Portfolio />} />
-          <Route path="/" element={<Navigate to="/login" replace />} />
+          <Route path="/" element={<Landing />} />
           <Route element={<Layout />}>
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/transactions" element={<Transactions />} />

--- a/frontend/vite-project/src/components/Layout.tsx
+++ b/frontend/vite-project/src/components/Layout.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { Link, useLocation, useNavigate, Outlet } from 'react-router-dom'
+import { authApi, demoApi } from '../services/api'
 
 const navItems = [
   { path: '/dashboard', label: 'Dashboard' },
@@ -41,9 +42,17 @@ const footerItems = [
   },
 ]
 
+export interface LayoutContext {
+  isDemo: boolean
+  remainingTrades: number
+  refreshDemoStatus: () => Promise<void>
+}
+
 export default function Layout() {
   const [isOpen, setIsOpen] = useState(() => window.innerWidth >= 1280)
   const [userManuallyClosed, setUserManuallyClosed] = useState(false)
+  const [isDemo, setIsDemo] = useState(false)
+  const [remainingTrades, setRemainingTrades] = useState(3)
   const location = useLocation()
   const navigate = useNavigate()
 
@@ -56,6 +65,32 @@ export default function Layout() {
     window.addEventListener('resize', handleResize)
     return () => window.removeEventListener('resize', handleResize)
   }, [userManuallyClosed])
+
+  const refreshDemoStatus = useCallback(async () => {
+    if (!isDemo) return
+    try {
+      const data = await demoApi.status() as { remainingTrades: number }
+      setRemainingTrades(data.remainingTrades)
+    } catch (e) {
+      console.error('Failed to fetch demo status:', e)
+    }
+  }, [isDemo])
+
+  useEffect(() => {
+    const loadAuth = async () => {
+      try {
+        const data = await authApi.me() as { isDemo?: boolean }
+        setIsDemo(data.isDemo ?? false)
+      } catch (e) {
+        console.error('Failed to fetch auth state:', e)
+      }
+    }
+    loadAuth()
+  }, [location.pathname])
+
+  useEffect(() => {
+    refreshDemoStatus()
+  }, [refreshDemoStatus])
 
   const handleLogout = async () => {
     try {
@@ -153,8 +188,17 @@ export default function Layout() {
 
       {/* Main Content */}
       <main className="flex-1 overflow-auto flex flex-col">
+        {isDemo && (
+          <div className={`px-6 py-2 text-sm font-130 ${
+            remainingTrades === 0
+              ? 'bg-error/20 text-error border-b border-error/30'
+              : 'bg-primary/10 text-primary border-b border-primary/20'
+          }`}>
+            Demo Mode — {remainingTrades} of 3 trades remaining. Changes are not saved.
+          </div>
+        )}
         <div className="flex-1">
-          <Outlet />
+          <Outlet context={{ isDemo, remainingTrades, refreshDemoStatus } as LayoutContext} />
         </div>
         <footer className="py-5 px-6 border-t border-border flex flex-col items-center gap-3 text-sm text-muted">
           <p className="font-90 text-secondary">

--- a/frontend/vite-project/src/components/Layout.tsx
+++ b/frontend/vite-project/src/components/Layout.tsx
@@ -101,7 +101,7 @@ export default function Layout() {
     } catch (error) {
       console.error('Logout error:', error)
     }
-    navigate('/login')
+    navigate('/')
   }
 
   return (

--- a/frontend/vite-project/src/components/landing/LandingCTA.tsx
+++ b/frontend/vite-project/src/components/landing/LandingCTA.tsx
@@ -1,0 +1,25 @@
+interface LandingCTAProps {
+  onDemoClick: () => void
+}
+
+export default function LandingCTA({ onDemoClick }: LandingCTAProps) {
+  return (
+    <div className="w-full max-w-xl mx-auto text-center">
+      <h2 className="text-3xl md:text-4xl font-150 text-foreground mb-4">Improve, one trade at a time</h2>
+      <p className="text-base text-secondary mb-8 leading-relaxed">
+        Vestry turns your portfolio history and notes into a clearer picture of
+        what works. Start with the demo and see how reflection shapes better
+        decisions.
+      </p>
+
+      <button
+        onClick={onDemoClick}
+        className="px-8 py-3 bg-primary text-primary-foreground rounded-md text-base font-130 hover:bg-primary-hover transition-colors cursor-pointer"
+      >
+        Try Demo Now
+      </button>
+
+      <p className="mt-4 text-xs text-muted">No account required. Limited to 3 demo trades.</p>
+    </div>
+  )
+}

--- a/frontend/vite-project/src/components/landing/LandingChart.tsx
+++ b/frontend/vite-project/src/components/landing/LandingChart.tsx
@@ -1,0 +1,177 @@
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Customized } from 'recharts'
+import { useXAxis, useYAxis } from 'recharts/es6/hooks'
+
+interface DataPoint {
+  time: number
+  label: string
+  value: number
+}
+
+interface LandingChartProps {
+  onBuyClick?: () => void
+}
+
+const BASE_DATE = new Date(2024, 0, 1)
+
+function parseTime(timeStr: string): number {
+  const [time, modifier] = timeStr.split(' ')
+  let [hours, minutes = 0] = time.split(':').map(Number)
+  if (modifier === 'PM' && hours !== 12) hours += 12
+  if (modifier === 'AM' && hours === 12) hours = 0
+  const date = new Date(BASE_DATE)
+  date.setHours(hours, minutes, 0, 0)
+  return date.getTime()
+}
+
+function formatTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+}
+
+const rawData = [
+  { time: '10 AM', value: 46000 },
+  { time: '11 AM', value: 47400 },
+  { time: '11:35 AM', value: 49000 },
+  { time: '12 PM', value: 46400 },
+  { time: '1 PM', value: 43900 },
+  { time: '1:45 PM', value: 46200 },
+  { time: '2 PM', value: 47400 },
+  { time: '3 PM', value: 45800 },
+  { time: '3:50 PM', value: 45250 },
+]
+
+const data: DataPoint[] = rawData.map((d) => ({
+  time: parseTime(d.time),
+  label: d.time,
+  value: d.value,
+}))
+
+const BUY_COLOR = '#10b981'
+const SELL_COLOR = '#ef4444'
+const INSIGHT_COLOR = '#5e9ed6'
+
+const xAxisTicks = rawData
+  .filter((d) => ['10 AM', '11 AM', '12 PM', '1 PM', '2 PM', '3 PM', '3:50 PM'].includes(d.time))
+  .map((d) => parseTime(d.time))
+
+const events = [
+  { time: parseTime('11:35 AM'), value: 49000, type: 'SELL', color: SELL_COLOR, label: 'Sell' },
+  { time: parseTime('1:45 PM'), value: 46200, type: 'INSIGHT', color: INSIGHT_COLOR, label: 'Insight' },
+  { time: parseTime('3:50 PM'), value: 45250, type: 'BUY', color: BUY_COLOR, label: 'BUY' },
+]
+
+function EventOverlay({ onBuyClick }: { onBuyClick?: () => void }) {
+  const xAxis = useXAxis(0)
+  const yAxis = useYAxis(0)
+
+  if (!xAxis || !yAxis) return null
+
+  return (
+    <g>
+      {events.map((event) => {
+        const cx = xAxis.scale(event.time)
+        const cy = yAxis.scale(event.value)
+        const isBuy = event.type === 'BUY'
+
+        return (
+          <g key={event.type}>
+            <circle
+              cx={cx}
+              cy={cy}
+              r={isBuy ? 10 : 4}
+              fill={event.color}
+              stroke="#32393d"
+              strokeWidth={isBuy ? 3 : 2}
+              style={{ cursor: isBuy ? 'pointer' : 'default' }}
+              onClick={isBuy ? onBuyClick : undefined}
+            />
+            <foreignObject
+              x={cx - 36}
+              y={isBuy ? cy - 40 : cy + 12}
+              width="72"
+              height="32"
+            >
+              {isBuy ? (
+                <button
+                  onClick={onBuyClick}
+                  className="inline-flex items-center justify-center gap-1.5 w-full h-full px-2 bg-gain/10 border border-gain/30 text-gain rounded-md text-xs font-130 uppercase tracking-wide hover:bg-gain/20 transition-colors cursor-pointer"
+                >
+                  <span className="w-2 h-2 rounded-full bg-gain animate-pulse" />
+                  BUY
+                </button>
+              ) : (
+                <div className="inline-flex items-center justify-center gap-1.5 w-full h-full px-2 bg-surface border border-border text-foreground rounded-md text-[10px] font-130 uppercase tracking-wide">
+                  <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: event.color }} />
+                  {event.label}
+                </div>
+              )}
+            </foreignObject>
+          </g>
+        )
+      })}
+    </g>
+  )
+}
+
+export default function LandingChart({ onBuyClick }: LandingChartProps) {
+  return (
+    <div className="w-full max-w-3xl mx-auto bg-surface p-6 rounded-lg border border-border">
+      <div className="mb-4">
+        <span className="text-xs font-130 uppercase text-muted tracking-wide">Portfolio Value</span>
+        <div className="text-2xl font-150 text-foreground mt-1">$45,250</div>
+      </div>
+
+      <div className="h-72">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 10, right: 20, bottom: 10, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
+            <XAxis
+              dataKey="time"
+              type="number"
+              scale="time"
+              domain={['dataMin', 'dataMax']}
+              ticks={xAxisTicks}
+              tickFormatter={formatTime}
+              stroke="#6b7280"
+              fontSize={12}
+              tickLine={false}
+              axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
+            />
+            <YAxis
+              stroke="#6b7280"
+              fontSize={12}
+              tickLine={false}
+              axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
+              tickFormatter={(value) => `$${(value / 1000).toFixed(0)}k`}
+              domain={['dataMin - 1000', 'dataMax + 1000']}
+            />
+            <Tooltip
+              formatter={(value: number) => [`$${value.toLocaleString()}`, 'Value']}
+              labelFormatter={(label) => formatTime(label as number)}
+              contentStyle={{
+                backgroundColor: '#32393d',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: '6px',
+                color: '#bdbdbd',
+              }}
+            />
+            <Line
+              type="monotone"
+              dataKey="value"
+              stroke="#10b981"
+              strokeWidth={2}
+              dot={false}
+              activeDot={{ r: 6, strokeWidth: 0 }}
+              isAnimationActive={true}
+              animationDuration={1000}
+            />
+            <Customized component={() => <EventOverlay onBuyClick={onBuyClick} />} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/frontend/vite-project/src/components/landing/LandingDetailCard.tsx
+++ b/frontend/vite-project/src/components/landing/LandingDetailCard.tsx
@@ -1,0 +1,103 @@
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceDot } from 'recharts'
+
+interface ChartPoint {
+  time: string
+  price: number
+}
+
+const history: ChartPoint[] = [
+  { time: 'Jun 12', price: 720 },
+  { time: 'Jun 13', price: 735 },
+  { time: 'Jun 16', price: 731 },
+  { time: 'Jun 17', price: 745 },
+  { time: 'Jun 18', price: 750 },
+]
+
+export default function LandingDetailCard() {
+  return (
+    <div className="w-full max-w-2xl mx-auto bg-surface rounded-lg border border-border p-6">
+      <div className="flex justify-between items-start mb-5">
+        <div>
+          <h3 className="text-2xl font-150 m-0 text-foreground">SPX</h3>
+          <span className="px-2 py-0.5 text-xs font-130 uppercase bg-gain/10 text-gain rounded">BUY</span>
+        </div>
+        <div className="text-right">
+          <div className="text-xs text-muted">Jun 18 3:50PM</div>
+          <div className="text-sm text-foreground mt-1">Snapshot: $750.00</div>
+        </div>
+      </div>
+
+      <p className="text-sm text-foreground leading-relaxed mb-5">
+        Review the entry against recent price action and identify what the trade
+        is telling you.
+      </p>
+
+      <div className="h-56 mb-5">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={history} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
+            <XAxis
+              dataKey="time"
+              stroke="#6b7280"
+              fontSize={12}
+              tickLine={false}
+              axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
+            />
+            <YAxis
+              stroke="#6b7280"
+              fontSize={12}
+              tickLine={false}
+              axisLine={{ stroke: 'rgba(255,255,255,0.08)' }}
+              tickFormatter={(value) => `$${value}`}
+              domain={['dataMin - 15', 'dataMax + 15']}
+            />
+            <Tooltip
+              formatter={(value: number) => [`$${value}`, 'Price']}
+              contentStyle={{
+                backgroundColor: '#32393d',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: '6px',
+                color: '#bdbdbd',
+              }}
+            />
+            <Line
+              type="monotone"
+              dataKey="price"
+              stroke="#10b981"
+              strokeWidth={2}
+              dot={false}
+              activeDot={{ r: 5 }}
+            />
+            <ReferenceDot
+              x="Jun 18"
+              y={750}
+              r={8}
+              fill="#10b981"
+              stroke="#fff"
+              strokeWidth={2}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="p-3 bg-surface-hover rounded-md border border-border">
+          <div className="text-xs text-muted mb-1">Entry Price</div>
+          <div className="text-sm font-130 text-foreground">$750.00</div>
+        </div>
+        <div className="p-3 bg-surface-hover rounded-md border border-border">
+          <div className="text-xs text-muted mb-1">Price Change</div>
+          <div className="text-sm font-130 text-gain">+$18.00 (+2.5%)</div>
+        </div>
+        <div className="p-3 bg-surface-hover rounded-md border border-border">
+          <div className="text-xs text-muted mb-1">Days Since</div>
+          <div className="text-sm font-130 text-foreground">3</div>
+        </div>
+        <div className="p-3 bg-surface-hover rounded-md border border-border">
+          <div className="text-xs text-muted mb-1">Position</div>
+          <div className="text-sm font-130 text-foreground">Long</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/vite-project/src/components/landing/LandingJournalCard.tsx
+++ b/frontend/vite-project/src/components/landing/LandingJournalCard.tsx
@@ -1,0 +1,24 @@
+export default function LandingJournalCard() {
+  return (
+    <div className="w-full max-w-lg mx-auto bg-surface-hover rounded-lg border border-border p-5 hover:border-primary/30 transition-colors">
+      <div className="flex justify-between items-start mb-3">
+        <div className="flex items-center gap-3">
+          <span className="px-2 py-1 text-xs font-130 uppercase bg-gain/10 text-gain rounded">BUY</span>
+          <span className="text-sm font-150 text-foreground">SPX</span>
+        </div>
+        <span className="text-xs text-muted">Jun 18 3:50PM</span>
+      </div>
+
+      <div className="text-xs text-muted mb-3">Snapshot: $750.00</div>
+
+      <p className="text-sm text-foreground leading-relaxed">
+        Bought SPX near the close. Want to remember why I entered and how the
+        thesis plays out over the next few sessions.
+      </p>
+
+      <div className="mt-4 pt-4 border-t border-border">
+        <span className="text-xs text-secondary italic">Reflect on your trades</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/vite-project/src/components/landing/LandingNav.tsx
+++ b/frontend/vite-project/src/components/landing/LandingNav.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { authApi } from '../../services/api'
+import { redirectAfterLogin } from '../../utils/redirectAfterLogin'
+
+export default function LandingNav() {
+  const navigate = useNavigate()
+  const [demoLoading, setDemoLoading] = useState(false)
+
+  const handleDemo = async () => {
+    setDemoLoading(true)
+    try {
+      await authApi.login('demo', 'demo')
+      await redirectAfterLogin(navigate)
+    } catch {
+      navigate('/login')
+    } finally {
+      setDemoLoading(false)
+    }
+  }
+
+  return (
+    <header className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-sm border-b border-border">
+      <div className="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
+        <span className="text-lg font-150 text-foreground">Vestry</span>
+
+        <nav className="flex items-center gap-3">
+          <a
+            href="/login"
+            className="px-3 py-1.5 text-sm text-foreground hover:text-primary transition-colors cursor-pointer"
+          >
+            Sign in
+          </a>
+          <button
+            type="button"
+            data-demo-button
+            onClick={handleDemo}
+            disabled={demoLoading}
+            className="px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary-hover transition-colors disabled:opacity-50 cursor-pointer"
+          >
+            Try Demo Now
+          </button>
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/frontend/vite-project/src/hooks/useScrollReveal.ts
+++ b/frontend/vite-project/src/hooks/useScrollReveal.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from 'react'
+
+export function useScrollReveal<T extends HTMLElement>() {
+  const ref = useRef<T>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+        }
+      },
+      { threshold: 0.2, rootMargin: '0px 0px -50px 0px' }
+    )
+
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return { ref, isVisible }
+}

--- a/frontend/vite-project/src/pages/Dashboard.tsx
+++ b/frontend/vite-project/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import { useOutletContext } from 'react-router-dom'
 import PortfolioChart from '../components/PortfolioChart'
 import type { PortfolioChartHandle } from '../components/PortfolioChart'
 import JournalPrompt from '../components/JournalPrompt'
@@ -12,6 +13,7 @@ import JournalDetailPanel from '../components/JournalDetailPanel'
 import type { PnLSummary } from '../types/transaction'
 import type { StockMetadata } from '../types/watchlist'
 import type { JournalEntry } from '../types/journal'
+import type { LayoutContext } from '../components/Layout'
 import { journalApi, portfolioApi } from '../services/api'
 
 type StockData = {
@@ -40,6 +42,7 @@ type Holding = {
 }
 
 export default function Dashboard() {
+  const { refreshDemoStatus } = useOutletContext<LayoutContext>()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string>('')
   const [results, setResults] = useState<Holding[]>([])
@@ -204,12 +207,17 @@ export default function Dashboard() {
       resetManualState()
       await fetchPortfolioInfo()
       await fetchPnLSummary()
+      await refreshDemoStatus()
       setJournalPromptTicker(boughtTicker)
       setJournalPromptTradeType('BUY')
       setShowJournalPrompt(true)
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Unexpected error'
-      setError(message)
+      if (message.includes('Demo trade limit reached')) {
+        setError('Demo trade limit reached. You can make up to 3 buy/sell actions in demo mode.')
+      } else {
+        setError(message)
+      }
     } finally {
       setLoading(false)
     }
@@ -255,12 +263,17 @@ export default function Dashboard() {
       closeSellModal()
       await fetchPortfolioInfo()
       await fetchPnLSummary()
+      await refreshDemoStatus()
       setJournalPromptTicker(soldTicker)
       setJournalPromptTradeType('SELL')
       setShowJournalPrompt(true)
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Unexpected error'
-      setError(message)
+      if (message.includes('Demo trade limit reached')) {
+        setError('Demo trade limit reached. You can make up to 3 buy/sell actions in demo mode.')
+      } else {
+        setError(message)
+      }
     } finally {
       setLoading(false)
     }

--- a/frontend/vite-project/src/pages/Dashboard.tsx
+++ b/frontend/vite-project/src/pages/Dashboard.tsx
@@ -356,6 +356,30 @@ export default function Dashboard() {
     }
   }, [])
 
+  // Subscribe to server-sent events for hourly price-fetch completion
+  useEffect(() => {
+    const eventSource = new EventSource('/api/events', { withCredentials: true })
+
+    eventSource.addEventListener('priceFetchCompleted', () => {
+      fetchPortfolioInfo()
+      fetchPnLSummary()
+      portfolioChartRef.current?.refresh()
+    })
+
+    eventSource.addEventListener('error', () => {
+      // The browser will auto-reconnect; if the error is fatal we close after a delay.
+      setTimeout(() => {
+        if (eventSource.readyState === EventSource.CLOSED) {
+          eventSource.close()
+        }
+      }, 5000)
+    })
+
+    return () => {
+      eventSource.close()
+    }
+  }, [])
+
   return (
     <div className="flex min-h-screen gap-6"> {/* if modifying sidebar gap also update Layout.tsx */}
       {/* Main Content */}

--- a/frontend/vite-project/src/pages/Landing.tsx
+++ b/frontend/vite-project/src/pages/Landing.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { authApi } from '../services/api'
+import { useScrollReveal } from '../hooks/useScrollReveal'
+import LandingNav from '../components/landing/LandingNav'
+import LandingChart from '../components/landing/LandingChart'
+import LandingJournalCard from '../components/landing/LandingJournalCard'
+import LandingDetailCard from '../components/landing/LandingDetailCard'
+import LandingCTA from '../components/landing/LandingCTA'
+
+const SECTIONS = ['track', 'reflect', 'analyze', 'improve']
+
+function RevealSection({ children, className }: { children: React.ReactNode; className?: string }) {
+  const { ref, isVisible } = useScrollReveal<HTMLDivElement>()
+
+  return (
+    <div
+      ref={ref}
+      className={`
+        transition-all duration-700 ease-out
+        ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}
+        ${className || ''}
+      `}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default function Landing() {
+  const navigate = useNavigate()
+  const [checkingAuth, setCheckingAuth] = useState(true)
+  const [activeSection, setActiveSection] = useState(0)
+  const sectionRefs = useRef<(HTMLElement | null)[]>([])
+
+  useEffect(() => {
+    document.title = 'Vestry | Portfolio Journal'
+
+    const checkAuth = async () => {
+      try {
+        const data = (await authApi.me()) as { username?: string | null } | null
+        if (data?.username) {
+          navigate('/dashboard', { replace: true })
+        }
+      } catch {
+        // Not authenticated, stay on landing
+      } finally {
+        setCheckingAuth(false)
+      }
+    }
+
+    checkAuth()
+  }, [navigate])
+
+  useEffect(() => {
+    const observers: IntersectionObserver[] = []
+
+    sectionRefs.current.forEach((el, index) => {
+      if (!el) return
+
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            setActiveSection(index)
+          }
+        },
+        { threshold: 0.5 }
+      )
+
+      observer.observe(el)
+      observers.push(observer)
+    })
+
+    return () => observers.forEach((o) => o.disconnect())
+  }, [checkingAuth])
+
+  const scrollTo = (id: string) => {
+    const el = document.getElementById(id)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }
+
+  if (checkingAuth) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <span className="text-muted">Loading…</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <LandingNav />
+
+      <div className="fixed left-6 top-1/2 -translate-y-1/2 z-40 hidden md:flex flex-col gap-4">
+        {SECTIONS.map((id, index) => (
+          <button
+            key={id}
+            onClick={() => scrollTo(id)}
+            className={`
+              h-[2px] rounded-full transition-all duration-300
+              ${index === activeSection
+                ? 'w-8 bg-primary'
+                : 'w-4 bg-foreground/30 hover:bg-foreground/60'
+              }
+            `}
+            aria-label={`Go to ${id} section`}
+          />
+        ))}
+      </div>
+
+      <main className="pt-14">
+        {/* Track */}
+        <section
+          id="track"
+          ref={(el) => { sectionRefs.current[0] = el }}
+          className="min-h-[calc(100vh-3.5rem)] flex flex-col justify-center px-6 py-16"
+        >
+          <RevealSection className="max-w-4xl mx-auto w-full">
+            <div className="text-center mb-10">
+              <h1 className="text-4xl md:text-5xl font-150 text-foreground mb-4">Track your decisions</h1>
+              <p className="text-base md:text-lg text-secondary max-w-xl mx-auto leading-relaxed">
+                Watch your portfolio unfold hour by hour. The big moments — like a
+                buy — stand out so you can revisit them later.
+              </p>
+            </div>
+
+            <LandingChart onBuyClick={() => scrollTo('reflect')} />
+          </RevealSection>
+        </section>
+
+        {/* Reflect */}
+        <section
+          id="reflect"
+          ref={(el) => { sectionRefs.current[1] = el }}
+          className="min-h-screen flex flex-col justify-center px-6 py-16"
+        >
+          <RevealSection className="max-w-3xl mx-auto w-full">
+            <div className="text-center mb-10">
+              <h2 className="text-3xl md:text-4xl font-150 text-foreground mb-4">Reflect on every trade</h2>
+              <p className="text-base text-secondary max-w-lg mx-auto leading-relaxed">
+                Attach context to each move. A short note today becomes a valuable
+                signal tomorrow.
+              </p>
+            </div>
+
+            <LandingJournalCard />
+          </RevealSection>
+        </section>
+
+        {/* Analyze */}
+        <section
+          id="analyze"
+          ref={(el) => { sectionRefs.current[2] = el }}
+          className="min-h-screen flex flex-col justify-center px-6 py-16"
+        >
+          <RevealSection className="max-w-3xl mx-auto w-full">
+            <div className="text-center mb-10">
+              <h2 className="text-3xl md:text-4xl font-150 text-foreground mb-4">Analyze what happened</h2>
+              <p className="text-base text-secondary max-w-lg mx-auto leading-relaxed">
+                See the entry against price history. Understand outcomes without
+                noise.
+              </p>
+            </div>
+
+            <LandingDetailCard />
+          </RevealSection>
+        </section>
+
+        {/* Improve */}
+        <section
+          id="improve"
+          ref={(el) => { sectionRefs.current[3] = el }}
+          className="min-h-screen flex flex-col justify-center px-6 py-16"
+        >
+          <RevealSection className="max-w-3xl mx-auto w-full">
+            <LandingCTA onDemoClick={() => {
+              const demoButton = document.querySelector('[data-demo-button]') as HTMLButtonElement | null
+              demoButton?.click()
+            }} />
+          </RevealSection>
+        </section>
+      </main>
+
+      <footer className="py-8 px-6 text-center text-sm text-muted">
+        <p className="font-90 mb-3">
+          Vestry is open-source. If you would like to self-host please follow the instructions on the GitHub repository.
+        </p>
+        <div className="flex items-center justify-center gap-4">
+          <a
+            href="https://github.com/fabianjim/vestry"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors"
+            aria-label="GitHub"
+          >
+            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+            </svg>
+          </a>
+          <a
+            href="mailto:fabian.jim26@gmail.com"
+            className="hover:text-foreground transition-colors"
+            aria-label="Email"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+          </a>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/frontend/vite-project/src/services/api.ts
+++ b/frontend/vite-project/src/services/api.ts
@@ -124,6 +124,15 @@ export const authApi = {
 
   logout: () =>
     apiClient('/auth/logout', { method: 'POST' }),
+
+  me: () =>
+    apiClient('/auth/me'),
+}
+
+// Demo API
+export const demoApi = {
+  status: () =>
+    apiClient('/portfolio/demo-status'),
 }
 
 export default apiClient

--- a/frontend/vite-project/src/utils/redirectAfterLogin.ts
+++ b/frontend/vite-project/src/utils/redirectAfterLogin.ts
@@ -1,0 +1,14 @@
+import { portfolioApi } from '../services/api'
+
+export async function redirectAfterLogin(navigate: (path: string) => void) {
+  try {
+    const hasPortfolio = await portfolioApi.portfolioExists() as boolean
+    if (hasPortfolio) {
+      navigate('/dashboard')
+    } else {
+      navigate('/portfolio')
+    }
+  } catch {
+    navigate('/portfolio')
+  }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/config/DemoSessionCleanupListener.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/config/DemoSessionCleanupListener.java
@@ -1,0 +1,51 @@
+package com.github.fabianjim.portfoliomonitor.config;
+
+import com.github.fabianjim.portfoliomonitor.model.DemoSession;
+import com.github.fabianjim.portfoliomonitor.model.Holding;
+import com.github.fabianjim.portfoliomonitor.model.TrackedStock;
+import com.github.fabianjim.portfoliomonitor.repository.TrackedStockRepository;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionResolver;
+import jakarta.servlet.annotation.WebListener;
+import jakarta.servlet.http.HttpSessionEvent;
+import jakarta.servlet.http.HttpSessionListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@WebListener
+public class DemoSessionCleanupListener implements HttpSessionListener {
+
+    private final TrackedStockRepository trackedStockRepository;
+
+    public DemoSessionCleanupListener(TrackedStockRepository trackedStockRepository) {
+        this.trackedStockRepository = trackedStockRepository;
+    }
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent event) {
+        Object demoSessionObj = event.getSession().getAttribute(DemoSessionResolver.DEMO_SESSION_KEY);
+        if (!(demoSessionObj instanceof DemoSession demoSession)) {
+            return;
+        }
+
+        if (demoSession.getPortfolio() == null || demoSession.getPortfolio().getHoldings() == null) {
+            return;
+        }
+
+        for (Holding holding : demoSession.getPortfolio().getHoldings()) {
+            stopTrackingStock(holding.getTicker());
+        }
+    }
+
+    private void stopTrackingStock(String ticker) {
+        TrackedStock trackedStock = trackedStockRepository.findByTicker(ticker).orElse(null);
+        if (trackedStock == null) {
+            return;
+        }
+        trackedStock.decrementHolderCount();
+        if (trackedStock.getHolderCount() <= 0) {
+            trackedStockRepository.delete(trackedStock);
+        } else {
+            trackedStockRepository.save(trackedStock);
+        }
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/controller/EventController.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/controller/EventController.java
@@ -1,0 +1,23 @@
+package com.github.fabianjim.portfoliomonitor.controller;
+
+import com.github.fabianjim.portfoliomonitor.event.PriceFetchEventService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/events")
+public class EventController {
+
+    private final PriceFetchEventService priceFetchEventService;
+
+    public EventController(PriceFetchEventService priceFetchEventService) {
+        this.priceFetchEventService = priceFetchEventService;
+    }
+
+    @GetMapping
+    public SseEmitter subscribe() {
+        return priceFetchEventService.subscribe();
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/controller/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.github.fabianjim.portfoliomonitor.controller;
 
+import com.github.fabianjim.portfoliomonitor.exception.DemoTradeLimitExceededException;
 import com.github.fabianjim.portfoliomonitor.exception.PriceFetchException;
 import com.github.fabianjim.portfoliomonitor.exception.UnknownTickerException;
 import org.springframework.http.HttpStatus;
@@ -24,6 +25,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.SERVICE_UNAVAILABLE)
                 .body(Map.of("error", e.getMessage()));
+    }
+
+    @ExceptionHandler(DemoTradeLimitExceededException.class)
+    public ResponseEntity<Map<String, String>> handleDemoTradeLimit(DemoTradeLimitExceededException e) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(Map.of("error", e.getMessage(), "demoTradeLimitReached", "true"));
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/controller/JournalEntryController.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/controller/JournalEntryController.java
@@ -1,7 +1,12 @@
 package com.github.fabianjim.portfoliomonitor.controller;
 
+import com.github.fabianjim.portfoliomonitor.model.DemoSession;
 import com.github.fabianjim.portfoliomonitor.model.JournalEntry;
+import com.github.fabianjim.portfoliomonitor.model.User;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionResolver;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionService;
 import com.github.fabianjim.portfoliomonitor.service.JournalEntryService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
@@ -12,38 +17,65 @@ import java.util.List;
 public class JournalEntryController {
 
     private final JournalEntryService journalEntryService;
+    private final DemoSessionResolver demoSessionResolver;
+    private final DemoSessionService demoSessionService;
 
-    public JournalEntryController(JournalEntryService journalEntryService) {
+    public JournalEntryController(JournalEntryService journalEntryService,
+                                  DemoSessionResolver demoSessionResolver,
+                                  DemoSessionService demoSessionService) {
         this.journalEntryService = journalEntryService;
+        this.demoSessionResolver = demoSessionResolver;
+        this.demoSessionService = demoSessionService;
     }
 
     @PostMapping
-    public JournalEntry createEntry(@RequestBody JournalEntry entry) {
+    public JournalEntry createEntry(@RequestBody JournalEntry entry, HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            DemoSession session = demoSessionResolver.resolveSession(request);
+            User user = demoSessionResolver.getCurrentUser();
+            return demoSessionService.createJournalEntry(session, user, entry);
+        }
         return journalEntryService.createEntry(entry);
     }
 
     @GetMapping
-    public List<JournalEntry> getEntries() {
+    public List<JournalEntry> getEntries(HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            return demoSessionService.getJournalEntries(demoSessionResolver.resolveSession(request));
+        }
         return journalEntryService.getEntriesForUser();
     }
 
     @GetMapping("/{ticker}")
-    public List<JournalEntry> getEntriesForTicker(@PathVariable String ticker) {
+    public List<JournalEntry> getEntriesForTicker(@PathVariable String ticker, HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            return demoSessionService.getJournalEntriesForTicker(demoSessionResolver.resolveSession(request), ticker);
+        }
         return journalEntryService.getEntriesForUserAndTicker(ticker);
     }
 
     @GetMapping("/range")
-    public List<JournalEntry> getEntriesInRange(@RequestParam Instant from, @RequestParam Instant to) {
+    public List<JournalEntry> getEntriesInRange(@RequestParam Instant from, @RequestParam Instant to, HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            return demoSessionService.getJournalEntriesInRange(demoSessionResolver.resolveSession(request), from, to);
+        }
         return journalEntryService.getEntriesInRange(from, to);
     }
 
     @DeleteMapping("/{id}")
-    public void deleteEntry(@PathVariable int id) {
-        journalEntryService.deleteEntry(id);
+    public void deleteEntry(@PathVariable int id, HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            demoSessionService.deleteJournalEntry(demoSessionResolver.resolveSession(request), id);
+        } else {
+            journalEntryService.deleteEntry(id);
+        }
     }
 
     @PutMapping("/{id}")
-    public JournalEntry updateEntry(@PathVariable int id, @RequestBody JournalEntry entry) {
+    public JournalEntry updateEntry(@PathVariable int id, @RequestBody JournalEntry entry, HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            return demoSessionService.updateJournalEntry(demoSessionResolver.resolveSession(request), id, entry.getBody());
+        }
         return journalEntryService.updateEntry(id, entry.getBody());
     }
 }

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/controller/LoginController.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/controller/LoginController.java
@@ -1,8 +1,11 @@
 package com.github.fabianjim.portfoliomonitor.controller;
 
+import com.github.fabianjim.portfoliomonitor.model.DemoSession;
 import com.github.fabianjim.portfoliomonitor.model.User;
 import com.github.fabianjim.portfoliomonitor.repository.UserRepository;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionService;
 
+import jakarta.servlet.http.HttpSession;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -18,12 +21,16 @@ import java.util.Optional;
 @RequestMapping("/api/auth")
 public class LoginController {
 
+    private static final String DEMO_SESSION_KEY = "DEMO_SESSION";
+
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final DemoSessionService demoSessionService;
 
-    public LoginController(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public LoginController(UserRepository userRepository, PasswordEncoder passwordEncoder, DemoSessionService demoSessionService) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.demoSessionService = demoSessionService;
     }
 
     @PostMapping("/register")
@@ -43,17 +50,17 @@ public class LoginController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request, HttpSession session) {
         Optional<User> foundUser = userRepository.findByUsername(request.username);
-        
+
         if (foundUser.isEmpty()) {
             return ResponseEntity.badRequest()
-                    .body(new LoginResponse("Invalid username or password", null, null));
+                    .body(new LoginResponse("Invalid username or password", null, null, false));
         }
         User user = foundUser.get();
         if (!passwordEncoder.matches(request.password, user.getPassword())) {
             return ResponseEntity.badRequest()
-                    .body(new LoginResponse("Invalid username or password", null, null));
+                    .body(new LoginResponse("Invalid username or password", null, null, false));
         }
 
         Authentication auth = new UsernamePasswordAuthenticationToken(
@@ -61,9 +68,25 @@ public class LoginController {
         );
         SecurityContextHolder.getContext().setAuthentication(auth);
 
+        if (user.isDemo()) {
+            DemoSession demoSession = demoSessionService.createSession(user);
+            session.setAttribute(DEMO_SESSION_KEY, demoSession);
+        }
+
         System.out.println("User " + user.getUsername() + " " + user.getId() + " logged in successfully.");
         return ResponseEntity.ok(
-                new LoginResponse("Login successful", user.getUsername(), user.getId())
+                new LoginResponse("Login successful", user.getUsername(), user.getId(), user.isDemo())
+        );
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<LoginResponse> me() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof User user)) {
+            return ResponseEntity.status(401).body(new LoginResponse("Not authenticated", null, null, false));
+        }
+        return ResponseEntity.ok(
+                new LoginResponse("Authenticated", user.getUsername(), user.getId(), user.isDemo())
         );
     }
 
@@ -86,7 +109,7 @@ public class LoginController {
         public String password;
     } 
 
-    public record LoginResponse(String message, String username, Integer userId) {}
+    public record LoginResponse(String message, String username, Integer userId, boolean isDemo) {}
 
     public record RegisterResponse(String message, String username) {}
 }

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/controller/PortfolioController.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/controller/PortfolioController.java
@@ -2,13 +2,18 @@ package com.github.fabianjim.portfoliomonitor.controller;
 
 import com.github.fabianjim.portfoliomonitor.dto.PnLSummaryDTO;
 import com.github.fabianjim.portfoliomonitor.dto.PortfolioHistoryDTO;
+import com.github.fabianjim.portfoliomonitor.model.DemoSession;
 import com.github.fabianjim.portfoliomonitor.model.Holding;
 import com.github.fabianjim.portfoliomonitor.model.Portfolio;
 import com.github.fabianjim.portfoliomonitor.model.Transaction;
+import com.github.fabianjim.portfoliomonitor.model.User;
 
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionResolver;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionService;
 import com.github.fabianjim.portfoliomonitor.service.NasdaqMetadataService;
 import com.github.fabianjim.portfoliomonitor.service.PortfolioService;
 import com.github.fabianjim.portfoliomonitor.service.TransactionService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
@@ -22,32 +27,57 @@ public class PortfolioController {
     private final PortfolioService portfolioService;
     private final TransactionService transactionService;
     private final NasdaqMetadataService nasdaqMetadataService;
+    private final DemoSessionResolver demoSessionResolver;
+    private final DemoSessionService demoSessionService;
 
-    public PortfolioController(PortfolioService portfolioService, TransactionService transactionService, NasdaqMetadataService nasdaqMetadataService) {
+    public PortfolioController(PortfolioService portfolioService, TransactionService transactionService,
+                               NasdaqMetadataService nasdaqMetadataService,
+                               DemoSessionResolver demoSessionResolver,
+                               DemoSessionService demoSessionService) {
         this.portfolioService = portfolioService;
         this.transactionService = transactionService;
         this.nasdaqMetadataService = nasdaqMetadataService;
+        this.demoSessionResolver = demoSessionResolver;
+        this.demoSessionService = demoSessionService;
     }
-    
+
     @PostMapping("/create")
-    public void createPortfolio(@RequestBody Portfolio portfolio) {
-        portfolioService.createPortfolio(portfolio);
+    public void createPortfolio(@RequestBody Portfolio portfolio, HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            DemoSession session = demoSessionResolver.resolveSession(request);
+            User user = demoSessionResolver.getCurrentUser();
+            demoSessionService.createPortfolio(session, user, portfolio);
+        } else {
+            portfolioService.createPortfolio(portfolio);
+        }
     }
 
     @GetMapping
-    public Portfolio getPortfolio() {
+    public Portfolio getPortfolio(HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            return demoSessionService.getPortfolio(demoSessionResolver.resolveSession(request));
+        }
         return portfolioService.getPortfolio();
     }
 
     @GetMapping("/exists")
-    public boolean exists() {
+    public boolean exists(HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            return demoSessionService.existsByUserId(demoSessionResolver.resolveSession(request));
+        }
         return portfolioService.existsByUserId();
     }
 
     @GetMapping("/holdings")
-    public List<Holding> fetchHoldings() {
-        Portfolio current = portfolioService.getPortfolio();
-        List<Holding> holdings = current != null ? current.getHoldings() : List.of();
+    public List<Holding> fetchHoldings(HttpServletRequest request) {
+        List<Holding> holdings;
+        if (demoSessionResolver.isDemoUser()) {
+            Portfolio current = demoSessionService.getPortfolio(demoSessionResolver.resolveSession(request));
+            holdings = current != null ? current.getHoldings() : List.of();
+        } else {
+            Portfolio current = portfolioService.getPortfolio();
+            holdings = current != null ? current.getHoldings() : List.of();
+        }
         for (Holding holding : holdings) {
             nasdaqMetadataService.lookupMetadata(holding.getTicker()).ifPresent(holding::setMetadata);
         }
@@ -55,44 +85,83 @@ public class PortfolioController {
     }
 
     @PostMapping("/holdings/add")
-    public void addHolding(@RequestBody Map<String, Object> request) {
+    public void addHolding(@RequestBody Map<String, Object> request, HttpServletRequest httpRequest) {
         String ticker = (String) request.get("ticker");
         double shares = ((Number) request.get("shares")).doubleValue();
         Double price = request.containsKey("price") ? ((Number) request.get("price")).doubleValue() : null;
         Instant timestamp = request.containsKey("timestamp") ? Instant.parse((String) request.get("timestamp")) : null;
-        portfolioService.addHolding(ticker, shares, price, timestamp);
+
+        if (demoSessionResolver.isDemoUser()) {
+            DemoSession session = demoSessionResolver.resolveSession(httpRequest);
+            User user = demoSessionResolver.getCurrentUser();
+            demoSessionService.addHolding(session, user, ticker, shares, price, timestamp);
+        } else {
+            portfolioService.addHolding(ticker, shares, price, timestamp);
+        }
     }
 
     @PostMapping("/holdings/remove")
-    public void removeHolding(@RequestBody Map<String, Object> request) {
+    public void removeHolding(@RequestBody Map<String, Object> request, HttpServletRequest httpRequest) {
         String ticker = (String) request.get("ticker");
         Double price = request.containsKey("price") ? ((Number) request.get("price")).doubleValue() : null;
         Instant timestamp = request.containsKey("timestamp") ? Instant.parse((String) request.get("timestamp")) : null;
-        portfolioService.removeHolding(ticker, price, timestamp);
+
+        if (demoSessionResolver.isDemoUser()) {
+            DemoSession session = demoSessionResolver.resolveSession(httpRequest);
+            User user = demoSessionResolver.getCurrentUser();
+            demoSessionService.removeHolding(session, user, ticker, price, timestamp);
+        } else {
+            portfolioService.removeHolding(ticker, price, timestamp);
+        }
     }
 
     @GetMapping("/history")
-    public List<PortfolioHistoryDTO> getPortfolioHistory() {
+    public List<PortfolioHistoryDTO> getPortfolioHistory(HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            return demoSessionService.getPortfolioHistory(demoSessionResolver.resolveSession(request));
+        }
         return portfolioService.getPortfolioHistory();
     }
 
     @GetMapping("/transactions")
-    public List<Transaction> getTransactionHistory() {
+    public List<Transaction> getTransactionHistory(HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            return demoSessionService.getTransactions(demoSessionResolver.resolveSession(request));
+        }
         return transactionService.getTransactionHistory();
     }
 
+    @GetMapping("/demo-status")
+    public Map<String, Object> getDemoStatus(HttpServletRequest request) {
+        if (!demoSessionResolver.isDemoUser()) {
+            throw new RuntimeException("Not a demo user");
+        }
+        DemoSession session = demoSessionResolver.resolveSession(request);
+        return Map.of("remainingTrades", session.getRemainingTrades());
+    }
+
     @GetMapping("/pnl")
-    public PnLSummaryDTO getPnLSummary() {
+    public PnLSummaryDTO getPnLSummary(HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            return demoSessionService.getPnLSummary(demoSessionResolver.resolveSession(request));
+        }
         return portfolioService.getPnLSummary();
     }
 
     @PostMapping("/holdings/sell")
-    public void sellHolding(@RequestBody Map<String, Object> request) {
+    public void sellHolding(@RequestBody Map<String, Object> request, HttpServletRequest httpRequest) {
         String ticker = (String) request.get("ticker");
         double shares = ((Number) request.get("shares")).doubleValue();
         Double price = request.containsKey("price") ? ((Number) request.get("price")).doubleValue() : null;
         Instant timestamp = request.containsKey("timestamp") ? Instant.parse((String) request.get("timestamp")) : null;
-        portfolioService.sellHolding(ticker, shares, price, timestamp);
+
+        if (demoSessionResolver.isDemoUser()) {
+            DemoSession session = demoSessionResolver.resolveSession(httpRequest);
+            User user = demoSessionResolver.getCurrentUser();
+            demoSessionService.sellHolding(session, user, ticker, shares, price, timestamp);
+        } else {
+            portfolioService.sellHolding(ticker, shares, price, timestamp);
+        }
     }
 
 }

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/controller/StockController.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/controller/StockController.java
@@ -1,13 +1,17 @@
 package com.github.fabianjim.portfoliomonitor.controller;
 
 import com.github.fabianjim.portfoliomonitor.dto.StockDataDTO;
+import com.github.fabianjim.portfoliomonitor.model.DemoSession;
 import com.github.fabianjim.portfoliomonitor.model.Portfolio;
 import com.github.fabianjim.portfoliomonitor.model.Stock;
 import com.github.fabianjim.portfoliomonitor.model.Stock.StockType;
 import com.github.fabianjim.portfoliomonitor.model.TrackedStock;
 import com.github.fabianjim.portfoliomonitor.repository.TrackedStockRepository;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionResolver;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionService;
 import com.github.fabianjim.portfoliomonitor.service.PortfolioService;
 import com.github.fabianjim.portfoliomonitor.service.StockService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
@@ -23,17 +27,28 @@ public class StockController {
     private final StockService stockService;
     private final PortfolioService portfolioService;
     private final TrackedStockRepository trackedStockRepository;
+    private final DemoSessionResolver demoSessionResolver;
+    private final DemoSessionService demoSessionService;
 
     public StockController(StockService stockService, PortfolioService portfolioService,
-                          TrackedStockRepository trackedStockRepository) {
+                          TrackedStockRepository trackedStockRepository,
+                          DemoSessionResolver demoSessionResolver,
+                          DemoSessionService demoSessionService) {
         this.stockService = stockService;
         this.portfolioService = portfolioService;
         this.trackedStockRepository = trackedStockRepository;
+        this.demoSessionResolver = demoSessionResolver;
+        this.demoSessionService = demoSessionService;
     }
 
     // initial manual fetch from the frontend before routine fetches
     @GetMapping("/fetch/initial")
-    public List<Stock> fectchInitialStocks() {
+    public List<Stock> fectchInitialStocks(HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            DemoSession session = demoSessionResolver.resolveSession(request);
+            List<String> tickers = demoSessionService.getTickersFromPortfolio(session);
+            return stockService.updateMultipleStocks(tickers, StockType.INITIAL);
+        }
         Portfolio portfolio = portfolioService.getPortfolio();
         List<String> tickers = portfolioService.getTickersfromPortfolio(portfolio);
         return stockService.updateMultipleStocks(tickers, StockType.INITIAL);

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/controller/WatchlistController.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/controller/WatchlistController.java
@@ -1,8 +1,13 @@
 package com.github.fabianjim.portfoliomonitor.controller;
 
+import com.github.fabianjim.portfoliomonitor.model.DemoSession;
+import com.github.fabianjim.portfoliomonitor.model.User;
 import com.github.fabianjim.portfoliomonitor.model.WatchlistItem;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionResolver;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionService;
 import com.github.fabianjim.portfoliomonitor.service.NasdaqMetadataService;
 import com.github.fabianjim.portfoliomonitor.service.WatchlistService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,21 +19,41 @@ public class WatchlistController {
 
     private final WatchlistService watchlistService;
     private final NasdaqMetadataService nasdaqMetadataService;
+    private final DemoSessionResolver demoSessionResolver;
+    private final DemoSessionService demoSessionService;
 
-    public WatchlistController(WatchlistService watchlistService, NasdaqMetadataService nasdaqMetadataService) {
+    public WatchlistController(WatchlistService watchlistService, NasdaqMetadataService nasdaqMetadataService,
+                               DemoSessionResolver demoSessionResolver,
+                               DemoSessionService demoSessionService) {
         this.watchlistService = watchlistService;
         this.nasdaqMetadataService = nasdaqMetadataService;
+        this.demoSessionResolver = demoSessionResolver;
+        this.demoSessionService = demoSessionService;
     }
 
     @PostMapping
-    public WatchlistItem addToWatchlist(@RequestBody Map<String, String> request) {
+    public WatchlistItem addToWatchlist(@RequestBody Map<String, String> request, HttpServletRequest httpRequest) {
         String ticker = request.get("ticker");
-        return watchlistService.addToWatchlist(ticker);
+        if (demoSessionResolver.isDemoUser()) {
+            DemoSession session = demoSessionResolver.resolveSession(httpRequest);
+            User user = demoSessionResolver.getCurrentUser();
+            WatchlistItem item = demoSessionService.addToWatchlist(session, user, ticker);
+            nasdaqMetadataService.lookupMetadata(item.getTicker()).ifPresent(item::setMetadata);
+            return item;
+        }
+        WatchlistItem item = watchlistService.addToWatchlist(ticker);
+        nasdaqMetadataService.lookupMetadata(item.getTicker()).ifPresent(item::setMetadata);
+        return item;
     }
 
     @GetMapping
-    public List<WatchlistItem> getWatchlist() {
-        List<WatchlistItem> items = watchlistService.getWatchlistForUser();
+    public List<WatchlistItem> getWatchlist(HttpServletRequest request) {
+        List<WatchlistItem> items;
+        if (demoSessionResolver.isDemoUser()) {
+            items = demoSessionService.getWatchlistItems(demoSessionResolver.resolveSession(request));
+        } else {
+            items = watchlistService.getWatchlistForUser();
+        }
         for (WatchlistItem item : items) {
             nasdaqMetadataService.lookupMetadata(item.getTicker()).ifPresent(item::setMetadata);
         }
@@ -36,7 +61,11 @@ public class WatchlistController {
     }
 
     @DeleteMapping("/{ticker}")
-    public void removeFromWatchlist(@PathVariable String ticker) {
-        watchlistService.removeFromWatchlist(ticker);
+    public void removeFromWatchlist(@PathVariable String ticker, HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            demoSessionService.removeFromWatchlist(demoSessionResolver.resolveSession(request), ticker);
+        } else {
+            watchlistService.removeFromWatchlist(ticker);
+        }
     }
 }

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/event/PriceFetchCompletedEvent.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/event/PriceFetchCompletedEvent.java
@@ -1,0 +1,28 @@
+package com.github.fabianjim.portfoliomonitor.event;
+
+import java.time.Instant;
+
+public class PriceFetchCompletedEvent {
+
+    private final Instant timestamp;
+    private final int tickerCount;
+    private final boolean eod;
+
+    public PriceFetchCompletedEvent(Instant timestamp, int tickerCount, boolean eod) {
+        this.timestamp = timestamp;
+        this.tickerCount = tickerCount;
+        this.eod = eod;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public int getTickerCount() {
+        return tickerCount;
+    }
+
+    public boolean isEod() {
+        return eod;
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/event/PriceFetchEventService.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/event/PriceFetchEventService.java
@@ -1,0 +1,86 @@
+package com.github.fabianjim.portfoliomonitor.event;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+@Service
+public class PriceFetchEventService {
+
+    private static final Logger logger = Logger.getLogger(PriceFetchEventService.class.getName());
+    private static final long SSE_TIMEOUT = 30 * 60 * 1000L;
+
+    private final List<SseEmitter> emitters = new ArrayList<>();
+
+    public SseEmitter subscribe() {
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT);
+        synchronized (emitters) {
+            emitters.add(emitter);
+        }
+
+        emitter.onCompletion(() -> removeEmitter(emitter));
+        emitter.onTimeout(() -> removeEmitter(emitter));
+        emitter.onError((e) -> removeEmitter(emitter));
+
+        try {
+            emitter.send(SseEmitter.event().name("connected").data("ok"));
+        } catch (IOException e) {
+            logger.warning("Failed to send SSE connected event: " + e.getMessage());
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+
+    @EventListener
+    public void handlePriceFetchCompleted(PriceFetchCompletedEvent event) {
+        synchronized (emitters) {
+            List<SseEmitter> deadEmitters = new ArrayList<>();
+            for (SseEmitter emitter : emitters) {
+                try {
+                    emitter.send(SseEmitter.event()
+                        .name("priceFetchCompleted")
+                        .data(new PriceFetchCompletedPayload(event.getTimestamp().toString(), event.getTickerCount(), event.isEod())));
+                } catch (IOException e) {
+                    deadEmitters.add(emitter);
+                }
+            }
+            emitters.removeAll(deadEmitters);
+        }
+    }
+
+    private void removeEmitter(SseEmitter emitter) {
+        synchronized (emitters) {
+            emitters.remove(emitter);
+        }
+    }
+
+    public static class PriceFetchCompletedPayload {
+        private final String timestamp;
+        private final int tickerCount;
+        private final boolean eod;
+
+        public PriceFetchCompletedPayload(String timestamp, int tickerCount, boolean eod) {
+            this.timestamp = timestamp;
+            this.tickerCount = tickerCount;
+            this.eod = eod;
+        }
+
+        public String getTimestamp() {
+            return timestamp;
+        }
+
+        public int getTickerCount() {
+            return tickerCount;
+        }
+
+        public boolean isEod() {
+            return eod;
+        }
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/exception/DemoTradeLimitExceededException.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/exception/DemoTradeLimitExceededException.java
@@ -1,0 +1,8 @@
+package com.github.fabianjim.portfoliomonitor.exception;
+
+public class DemoTradeLimitExceededException extends RuntimeException {
+
+    public DemoTradeLimitExceededException() {
+        super("Demo trade limit reached. You can make up to 3 buy/sell actions in demo mode.");
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/model/DemoSession.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/model/DemoSession.java
@@ -1,0 +1,61 @@
+package com.github.fabianjim.portfoliomonitor.model;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DemoSession implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Portfolio portfolio;
+    private List<Transaction> transactions = new ArrayList<>();
+    private List<JournalEntry> journalEntries = new ArrayList<>();
+    private List<WatchlistItem> watchlistItems = new ArrayList<>();
+    private int remainingTrades = 3;
+    private int nextId = -1;
+
+    public Portfolio getPortfolio() {
+        return portfolio;
+    }
+
+    public void setPortfolio(Portfolio portfolio) {
+        this.portfolio = portfolio;
+    }
+
+    public List<Transaction> getTransactions() {
+        return transactions;
+    }
+
+    public void setTransactions(List<Transaction> transactions) {
+        this.transactions = transactions;
+    }
+
+    public List<JournalEntry> getJournalEntries() {
+        return journalEntries;
+    }
+
+    public void setJournalEntries(List<JournalEntry> journalEntries) {
+        this.journalEntries = journalEntries;
+    }
+
+    public List<WatchlistItem> getWatchlistItems() {
+        return watchlistItems;
+    }
+
+    public void setWatchlistItems(List<WatchlistItem> watchlistItems) {
+        this.watchlistItems = watchlistItems;
+    }
+
+    public int getRemainingTrades() {
+        return remainingTrades;
+    }
+
+    public void setRemainingTrades(int remainingTrades) {
+        this.remainingTrades = remainingTrades;
+    }
+
+    public int nextId() {
+        return nextId--;
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/model/User.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/model/User.java
@@ -18,6 +18,9 @@ public class User {
     @Column(nullable = false)
     private String password;
 
+    @Column(name = "is_demo", nullable = false)
+    private boolean demo = false;
+
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
     @JsonIgnore
     private Portfolio portfolio;
@@ -59,5 +62,13 @@ public class User {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public boolean isDemo() {
+        return demo;
+    }
+
+    public void setDemo(boolean demo) {
+        this.demo = demo;
     }
 }

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionResolver.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionResolver.java
@@ -1,0 +1,43 @@
+package com.github.fabianjim.portfoliomonitor.service;
+
+import com.github.fabianjim.portfoliomonitor.model.DemoSession;
+import com.github.fabianjim.portfoliomonitor.model.User;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DemoSessionResolver {
+
+    public static final String DEMO_SESSION_KEY = "DEMO_SESSION";
+
+    public boolean isDemoUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof User user)) {
+            return false;
+        }
+        return user.isDemo();
+    }
+
+    public DemoSession resolveSession(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            throw new RuntimeException("Demo session not found");
+        }
+        DemoSession demoSession = (DemoSession) session.getAttribute(DEMO_SESSION_KEY);
+        if (demoSession == null) {
+            throw new RuntimeException("Demo session not found");
+        }
+        return demoSession;
+    }
+
+    public User getCurrentUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof User user)) {
+            throw new RuntimeException("No authenticated user found");
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionService.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionService.java
@@ -1,0 +1,547 @@
+package com.github.fabianjim.portfoliomonitor.service;
+
+import com.github.fabianjim.portfoliomonitor.dto.PnLSummaryDTO;
+import com.github.fabianjim.portfoliomonitor.dto.PortfolioHistoryDTO;
+import com.github.fabianjim.portfoliomonitor.exception.DemoTradeLimitExceededException;
+import com.github.fabianjim.portfoliomonitor.exception.PriceFetchException;
+import com.github.fabianjim.portfoliomonitor.exception.UnknownTickerException;
+import com.github.fabianjim.portfoliomonitor.model.DemoSession;
+import com.github.fabianjim.portfoliomonitor.model.Holding;
+import com.github.fabianjim.portfoliomonitor.model.JournalEntry;
+import com.github.fabianjim.portfoliomonitor.model.Portfolio;
+import com.github.fabianjim.portfoliomonitor.model.Stock;
+import com.github.fabianjim.portfoliomonitor.model.Transaction;
+import com.github.fabianjim.portfoliomonitor.model.WatchlistItem;
+import com.github.fabianjim.portfoliomonitor.repository.HoldingRepository;
+import com.github.fabianjim.portfoliomonitor.repository.JournalEntryRepository;
+import com.github.fabianjim.portfoliomonitor.repository.PortfolioRepository;
+import com.github.fabianjim.portfoliomonitor.repository.StockRepository;
+import com.github.fabianjim.portfoliomonitor.repository.TransactionRepository;
+import com.github.fabianjim.portfoliomonitor.repository.WatchlistItemRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class DemoSessionService {
+
+    private final PortfolioRepository portfolioRepository;
+    private final HoldingRepository holdingRepository;
+    private final TransactionRepository transactionRepository;
+    private final JournalEntryRepository journalEntryRepository;
+    private final WatchlistItemRepository watchlistItemRepository;
+    private final StockRepository stockRepository;
+    private final StockService stockService;
+
+    public DemoSessionService(PortfolioRepository portfolioRepository,
+                              HoldingRepository holdingRepository,
+                              TransactionRepository transactionRepository,
+                              JournalEntryRepository journalEntryRepository,
+                              WatchlistItemRepository watchlistItemRepository,
+                              StockRepository stockRepository,
+                              StockService stockService) {
+        this.portfolioRepository = portfolioRepository;
+        this.holdingRepository = holdingRepository;
+        this.transactionRepository = transactionRepository;
+        this.journalEntryRepository = journalEntryRepository;
+        this.watchlistItemRepository = watchlistItemRepository;
+        this.stockRepository = stockRepository;
+        this.stockService = stockService;
+    }
+
+    public DemoSession createSession(com.github.fabianjim.portfoliomonitor.model.User user) {
+        DemoSession session = new DemoSession();
+
+        Portfolio dbPortfolio = portfolioRepository.findByUserId(user.getId()).orElse(null);
+        if (dbPortfolio != null) {
+            Portfolio portfolioCopy = new Portfolio();
+            portfolioCopy.setId(session.nextId());
+            portfolioCopy.setUser(user);
+
+            List<Holding> holdingsCopy = new ArrayList<>();
+            if (dbPortfolio.getHoldings() != null) {
+                for (Holding h : dbPortfolio.getHoldings()) {
+                    Holding copy = new Holding(h.getTicker(), h.getShares());
+                    copy.setId(session.nextId());
+                    copy.setBuyTimestamp(h.getBuyTimestamp());
+                    copy.setMetadata(h.getMetadata());
+                    holdingsCopy.add(copy);
+                }
+            }
+            portfolioCopy.setHoldings(holdingsCopy);
+            session.setPortfolio(portfolioCopy);
+        }
+
+        List<Transaction> txCopy = new ArrayList<>();
+        for (Transaction tx : transactionRepository.findByUserIdOrderByTimestampDesc(user.getId())) {
+            Transaction copy = new Transaction(tx.getTicker(), tx.getShares(), tx.getPrice(), tx.getType(), tx.isInitial());
+            copy.setId(session.nextId());
+            copy.setTimestamp(tx.getTimestamp());
+            copy.setTotalValue(tx.getTotalValue());
+            copy.setUser(user);
+            txCopy.add(copy);
+        }
+        session.setTransactions(txCopy);
+
+        List<JournalEntry> journalCopy = new ArrayList<>();
+        for (JournalEntry entry : journalEntryRepository.findByUserIdOrderByTimestampDesc(user.getId())) {
+            JournalEntry copy = new JournalEntry();
+            copy.setId(session.nextId());
+            copy.setEntryType(entry.getEntryType());
+            copy.setBody(entry.getBody());
+            copy.setTicker(entry.getTicker());
+            copy.setTimestamp(entry.getTimestamp());
+            copy.setPriceSnapshot(entry.getPriceSnapshot());
+            copy.setUser(user);
+            journalCopy.add(copy);
+        }
+        session.setJournalEntries(journalCopy);
+
+        List<WatchlistItem> watchlistCopy = new ArrayList<>();
+        for (WatchlistItem item : watchlistItemRepository.findByUserId(user.getId())) {
+            WatchlistItem copy = new WatchlistItem();
+            copy.setId(session.nextId());
+            copy.setTicker(item.getTicker());
+            copy.setUser(user);
+            copy.setMetadata(item.getMetadata());
+            watchlistCopy.add(copy);
+        }
+        session.setWatchlistItems(watchlistCopy);
+
+        return session;
+    }
+
+    public Portfolio getPortfolio(DemoSession session) {
+        return session.getPortfolio();
+    }
+
+    public boolean existsByUserId(DemoSession session) {
+        return session.getPortfolio() != null;
+    }
+
+    public void createPortfolio(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, Portfolio portfolio) {
+        if (portfolio != null && portfolio.getHoldings() != null) {
+            Map<String, Holding> byTicker = new HashMap<>();
+            List<Holding> aggregated = new ArrayList<>();
+            for (Holding holding : portfolio.getHoldings()) {
+                Holding existing = byTicker.get(holding.getTicker());
+                if (existing != null) {
+                    existing.setShares(existing.getShares() + holding.getShares());
+                } else {
+                    Holding copy = new Holding(holding.getTicker(), holding.getShares());
+                    copy.setId(session.nextId());
+                    byTicker.put(holding.getTicker(), copy);
+                    aggregated.add(copy);
+                }
+            }
+
+            Map<String, Double> tickerPrices = new HashMap<>();
+            for (Holding holding : aggregated) {
+                tickerPrices.put(holding.getTicker(), fetchTransactionPrice(holding.getTicker()));
+            }
+
+            Portfolio newPortfolio = new Portfolio();
+            newPortfolio.setId(session.nextId());
+            newPortfolio.setUser(user);
+            newPortfolio.setHoldings(aggregated);
+            session.setPortfolio(newPortfolio);
+
+            for (Holding holding : aggregated) {
+                double price = tickerPrices.get(holding.getTicker());
+                recordBuyTransaction(session, user, holding.getTicker(), holding.getShares(), price, holding.getBuyTimestamp(), true);
+            }
+        }
+    }
+
+    public void addHolding(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, String ticker, double shares, Double price, Instant timestamp) {
+        assertTradeRemaining(session);
+        Portfolio portfolio = session.getPortfolio();
+        if (portfolio == null) {
+            throw new RuntimeException("No portfolio found for current user");
+        }
+
+        double currentPrice = (price != null && price > 0) ? price : fetchTransactionPrice(ticker);
+
+        Holding existing = portfolio.getHoldings().stream()
+            .filter(h -> h.getTicker().equals(ticker))
+            .findFirst()
+            .orElse(null);
+
+        if (existing != null) {
+            existing.setShares(existing.getShares() + shares);
+        } else {
+            Holding newHolding = new Holding(ticker, shares);
+            newHolding.setId(session.nextId());
+            if (timestamp != null) {
+                newHolding.setBuyTimestamp(timestamp);
+            }
+            portfolio.getHoldings().add(newHolding);
+        }
+
+        session.setRemainingTrades(session.getRemainingTrades() - 1);
+        recordBuyTransaction(session, user, ticker, shares, currentPrice, timestamp, false);
+    }
+
+    public void removeHolding(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, String ticker, Double price, Instant timestamp) {
+        assertTradeRemaining(session);
+        Portfolio portfolio = session.getPortfolio();
+        if (portfolio == null) {
+            throw new RuntimeException("No portfolio found for current user");
+        }
+
+        Holding holding = portfolio.getHoldings().stream()
+            .filter(h -> h.getTicker().equals(ticker))
+            .findFirst()
+            .orElse(null);
+        if (holding == null) {
+            return;
+        }
+        double shares = holding.getShares();
+        double currentPrice = (price != null && price > 0) ? price : fetchTransactionPrice(ticker);
+
+        portfolio.getHoldings().remove(holding);
+        session.setRemainingTrades(session.getRemainingTrades() - 1);
+        recordSellTransaction(session, user, ticker, shares, currentPrice, timestamp);
+    }
+
+    public void sellHolding(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, String ticker, double sharesToSell, Double price, Instant timestamp) {
+        assertTradeRemaining(session);
+        Portfolio portfolio = session.getPortfolio();
+        if (portfolio == null) {
+            throw new RuntimeException("No portfolio found for current user");
+        }
+
+        Holding holding = portfolio.getHoldings().stream()
+            .filter(h -> h.getTicker().equals(ticker))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("Holding not found for ticker: " + ticker));
+
+        if (sharesToSell > holding.getShares()) {
+            throw new RuntimeException("Cannot sell more shares than owned");
+        }
+
+        double currentPrice = (price != null && price > 0) ? price : fetchTransactionPrice(ticker);
+
+        session.setRemainingTrades(session.getRemainingTrades() - 1);
+        recordSellTransaction(session, user, ticker, sharesToSell, currentPrice, timestamp);
+
+        if (sharesToSell == holding.getShares()) {
+            portfolio.getHoldings().remove(holding);
+        } else {
+            holding.setShares(holding.getShares() - sharesToSell);
+        }
+    }
+
+    private void assertTradeRemaining(DemoSession session) {
+        if (session.getRemainingTrades() <= 0) {
+            throw new DemoTradeLimitExceededException();
+        }
+    }
+
+    private double fetchTransactionPrice(String ticker) {
+        Exception lastError = null;
+        for (int attempt = 1; attempt <= 2; attempt++) {
+            try {
+                Stock stock = stockService.updateStockData(ticker, Stock.StockType.INITIAL);
+                if (stock != null && stock.getCurrentPrice() > 0.0) {
+                    return stock.getCurrentPrice();
+                }
+                if (stock == null) {
+                    lastError = new PriceFetchException(ticker, "No stock data returned");
+                } else {
+                    lastError = new PriceFetchException(ticker, "Invalid price (" + stock.getCurrentPrice() + ")");
+                }
+            } catch (UnknownTickerException e) {
+                throw e;
+            } catch (Exception e) {
+                lastError = e;
+            }
+            if (attempt == 1) {
+                try {
+                    TimeUnit.MILLISECONDS.sleep(500);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new PriceFetchException(ticker, "Retry interrupted", ie);
+                }
+            }
+        }
+        throw new PriceFetchException(ticker, lastError.getMessage(), lastError);
+    }
+
+    private Transaction recordBuyTransaction(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, String ticker, double shares, double price, Instant timestamp, boolean isInitial) {
+        Transaction transaction = new Transaction(ticker, shares, price, Transaction.TransactionType.BUY, isInitial);
+        if (timestamp != null) {
+            transaction.setTimestamp(timestamp);
+        }
+        transaction.setTotalValue(shares * price);
+        transaction.setUser(user);
+        transaction.setId(session.nextId());
+        session.getTransactions().add(transaction);
+        return transaction;
+    }
+
+    private Transaction recordSellTransaction(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, String ticker, double shares, double price, Instant timestamp) {
+        Transaction transaction = new Transaction(ticker, shares, price, Transaction.TransactionType.SELL, false);
+        if (timestamp != null) {
+            transaction.setTimestamp(timestamp);
+        }
+        transaction.setTotalValue(shares * price);
+        transaction.setUser(user);
+        transaction.setId(session.nextId());
+        session.getTransactions().add(transaction);
+        return transaction;
+    }
+
+    public List<Transaction> getTransactions(DemoSession session) {
+        List<Transaction> result = new ArrayList<>(session.getTransactions());
+        result.sort(Comparator.comparing(Transaction::getTimestamp).reversed());
+        return result;
+    }
+
+    public PnLSummaryDTO getPnLSummary(DemoSession session) {
+        List<Transaction> transactions = session.getTransactions();
+
+        Map<String, List<Transaction>> byTicker = new HashMap<>();
+        for (Transaction tx : transactions) {
+            byTicker.computeIfAbsent(tx.getTicker(), k -> new ArrayList<>()).add(tx);
+        }
+
+        double totalUnrealized = 0;
+        double totalRealized = 0;
+        double totalCurrentCostBasis = 0;
+        double totalSoldCostBasis = 0;
+
+        for (List<Transaction> tickerTxs : byTicker.values()) {
+            double buyShares = 0;
+            double buyCost = 0;
+            double sellShares = 0;
+            double sellProceeds = 0;
+
+            for (Transaction tx : tickerTxs) {
+                if (tx.getType() == Transaction.TransactionType.BUY) {
+                    buyShares += tx.getShares();
+                    buyCost += tx.getTotalValue();
+                } else {
+                    sellShares += tx.getShares();
+                    sellProceeds += tx.getTotalValue();
+                }
+            }
+
+            if (buyShares == 0) continue;
+
+            double avgCost = buyCost / buyShares;
+            double realizedForTicker = sellProceeds - (avgCost * sellShares);
+            totalRealized += realizedForTicker;
+            totalSoldCostBasis += avgCost * sellShares;
+
+            double currentShares = buyShares - sellShares;
+            if (currentShares > 0) {
+                String ticker = tickerTxs.get(0).getTicker();
+                double currentPrice = stockService.getLatestStockData(ticker)
+                    .map(Stock::getCurrentPrice)
+                    .orElse(0.0);
+                double unrealizedForTicker = (currentPrice - avgCost) * currentShares;
+                totalUnrealized += unrealizedForTicker;
+                totalCurrentCostBasis += avgCost * currentShares;
+            }
+        }
+
+        double totalPnL = totalUnrealized + totalRealized;
+        double totalCostBasis = totalCurrentCostBasis + totalSoldCostBasis;
+        double totalPnLPercent = totalCostBasis > 0 ? (totalPnL / totalCostBasis) * 100 : 0;
+        double unrealizedPercent = totalCurrentCostBasis > 0 ? (totalUnrealized / totalCurrentCostBasis) * 100 : 0;
+        double realizedPercent = totalSoldCostBasis > 0 ? (totalRealized / totalSoldCostBasis) * 100 : 0;
+
+        return new PnLSummaryDTO(totalPnL, totalPnLPercent, totalUnrealized, unrealizedPercent, totalRealized, realizedPercent);
+    }
+
+    public List<PortfolioHistoryDTO> getPortfolioHistory(DemoSession session) {
+        Portfolio portfolio = session.getPortfolio();
+        if (portfolio == null || portfolio.getHoldings() == null || portfolio.getHoldings().isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<Holding> holdings = portfolio.getHoldings();
+        List<Transaction> transactions = session.getTransactions();
+        Map<String, List<Transaction>> transactionsByTicker = new HashMap<>();
+        for (Transaction tx : transactions) {
+            transactionsByTicker.computeIfAbsent(tx.getTicker(), k -> new ArrayList<>()).add(tx);
+        }
+
+        Map<Instant, Map<String, Stock>> dataByHourBucket = new HashMap<>();
+
+        for (Holding holding : holdings) {
+            List<Stock> stockHistory = stockRepository.findByTickerOrderByTimestampDesc(holding.getTicker());
+            for (Stock stock : stockHistory) {
+                if (stock.getType() == Stock.StockType.EOD) {
+                    continue;
+                }
+
+                Instant effectiveBucket = stock.getHourBucket();
+                if (stock.getType() == Stock.StockType.INITIAL) {
+                    effectiveBucket = effectiveBucket.truncatedTo(ChronoUnit.MINUTES);
+                }
+
+                if (stock.getType() == Stock.StockType.INITIAL ||
+                    !effectiveBucket.isBefore(holding.getBuyTimestamp())) {
+                    dataByHourBucket
+                        .computeIfAbsent(effectiveBucket, k -> new HashMap<>())
+                        .put(stock.getTicker(), stock);
+                }
+            }
+        }
+
+        List<PortfolioHistoryDTO> result = new ArrayList<>();
+
+        for (Map.Entry<Instant, Map<String, Stock>> entry : dataByHourBucket.entrySet()) {
+            Instant hourBucket = entry.getKey();
+            Map<String, Stock> stocksAtHour = entry.getValue();
+
+            Map<String, Double> sharesAtTime = new HashMap<>();
+            for (Map.Entry<String, List<Transaction>> tickerTxs : transactionsByTicker.entrySet()) {
+                String ticker = tickerTxs.getKey();
+                double shares = 0;
+                for (Transaction tx : tickerTxs.getValue()) {
+                    Instant txMinute = tx.getTimestamp().truncatedTo(ChronoUnit.MINUTES);
+                    if (!txMinute.isAfter(hourBucket)) {
+                        if (tx.getType() == Transaction.TransactionType.BUY) {
+                            shares += tx.getShares();
+                        } else {
+                            shares -= tx.getShares();
+                        }
+                    }
+                }
+                if (shares > 0) {
+                    sharesAtTime.put(ticker, shares);
+                }
+            }
+
+            if (stocksAtHour.size() >= sharesAtTime.size()) {
+                double totalValue = 0.0;
+                boolean hasAllData = true;
+
+                for (Map.Entry<String, Double> shareEntry : sharesAtTime.entrySet()) {
+                    String ticker = shareEntry.getKey();
+                    double shares = shareEntry.getValue();
+                    Stock stock = stocksAtHour.get(ticker);
+
+                    if (stock == null) {
+                        hasAllData = false;
+                        break;
+                    }
+
+                    totalValue += stock.getCurrentPrice() * shares;
+                }
+
+                if (hasAllData && !sharesAtTime.isEmpty()) {
+                    result.add(new PortfolioHistoryDTO(hourBucket, totalValue));
+                }
+            }
+        }
+
+        result.sort(Comparator.comparing(PortfolioHistoryDTO::getTimestamp));
+        return result;
+    }
+
+    public List<String> getTickersFromPortfolio(DemoSession session) {
+        Portfolio portfolio = session.getPortfolio();
+        if (portfolio == null || portfolio.getHoldings() == null) {
+            return List.of();
+        }
+        return portfolio.getHoldings().stream()
+            .map(Holding::getTicker)
+            .distinct()
+            .toList();
+    }
+
+    public JournalEntry createJournalEntry(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, JournalEntry entry) {
+        entry.setUser(user);
+        entry.setId(session.nextId());
+        if (entry.getTimestamp() == null) {
+            entry.setTimestamp(Instant.now());
+        }
+        if (entry.getPriceSnapshot() == null) {
+            if (entry.getTicker() != null && !entry.getTicker().isBlank()) {
+                entry.setPriceSnapshot(stockService.getLatestStockData(entry.getTicker())
+                    .map(Stock::getCurrentPrice)
+                    .orElse(0.0));
+            } else {
+                entry.setPriceSnapshot(null);
+            }
+        }
+        session.getJournalEntries().add(entry);
+        return entry;
+    }
+
+    public List<JournalEntry> getJournalEntries(DemoSession session) {
+        List<JournalEntry> result = new ArrayList<>(session.getJournalEntries());
+        result.sort(Comparator.comparing(JournalEntry::getTimestamp).reversed());
+        return result;
+    }
+
+    public List<JournalEntry> getJournalEntriesForTicker(DemoSession session, String ticker) {
+        return getJournalEntries(session).stream()
+            .filter(e -> ticker.equals(e.getTicker()))
+            .toList();
+    }
+
+    public List<JournalEntry> getJournalEntriesInRange(DemoSession session, Instant from, Instant to) {
+        return getJournalEntries(session).stream()
+            .filter(e -> !e.getTimestamp().isBefore(from) && !e.getTimestamp().isAfter(to))
+            .toList();
+    }
+
+    public void deleteJournalEntry(DemoSession session, int id) {
+        boolean removed = session.getJournalEntries().removeIf(e -> e.getId() == id);
+        if (!removed) {
+            throw new RuntimeException("Journal entry not found");
+        }
+    }
+
+    public JournalEntry updateJournalEntry(DemoSession session, int id, String body) {
+        Optional<JournalEntry> entryOpt = session.getJournalEntries().stream()
+            .filter(e -> e.getId() == id)
+            .findFirst();
+        if (entryOpt.isEmpty()) {
+            throw new RuntimeException("Journal entry not found");
+        }
+        JournalEntry entry = entryOpt.get();
+        entry.setBody(body);
+        return entry;
+    }
+
+    public WatchlistItem addToWatchlist(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, String ticker) {
+        String normalizedTicker = ticker.trim().toUpperCase();
+        boolean exists = session.getWatchlistItems().stream()
+            .anyMatch(item -> item.getTicker().equals(normalizedTicker));
+        if (exists) {
+            throw new RuntimeException("Ticker already in watchlist");
+        }
+        WatchlistItem item = new WatchlistItem();
+        item.setId(session.nextId());
+        item.setUser(user);
+        item.setTicker(normalizedTicker);
+        session.getWatchlistItems().add(item);
+        return item;
+    }
+
+    public List<WatchlistItem> getWatchlistItems(DemoSession session) {
+        return new ArrayList<>(session.getWatchlistItems());
+    }
+
+    public void removeFromWatchlist(DemoSession session, String ticker) {
+        String normalizedTicker = ticker.trim().toUpperCase();
+        boolean removed = session.getWatchlistItems().removeIf(item -> item.getTicker().equals(normalizedTicker));
+        if (!removed) {
+            throw new RuntimeException("Watchlist item not found");
+        }
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionService.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionService.java
@@ -12,10 +12,12 @@ import com.github.fabianjim.portfoliomonitor.model.Portfolio;
 import com.github.fabianjim.portfoliomonitor.model.Stock;
 import com.github.fabianjim.portfoliomonitor.model.Transaction;
 import com.github.fabianjim.portfoliomonitor.model.WatchlistItem;
+import com.github.fabianjim.portfoliomonitor.model.TrackedStock;
 import com.github.fabianjim.portfoliomonitor.repository.HoldingRepository;
 import com.github.fabianjim.portfoliomonitor.repository.JournalEntryRepository;
 import com.github.fabianjim.portfoliomonitor.repository.PortfolioRepository;
 import com.github.fabianjim.portfoliomonitor.repository.StockRepository;
+import com.github.fabianjim.portfoliomonitor.repository.TrackedStockRepository;
 import com.github.fabianjim.portfoliomonitor.repository.TransactionRepository;
 import com.github.fabianjim.portfoliomonitor.repository.WatchlistItemRepository;
 import org.springframework.stereotype.Service;
@@ -40,6 +42,7 @@ public class DemoSessionService {
     private final WatchlistItemRepository watchlistItemRepository;
     private final StockRepository stockRepository;
     private final StockService stockService;
+    private final TrackedStockRepository trackedStockRepository;
 
     public DemoSessionService(PortfolioRepository portfolioRepository,
                               HoldingRepository holdingRepository,
@@ -47,7 +50,8 @@ public class DemoSessionService {
                               JournalEntryRepository journalEntryRepository,
                               WatchlistItemRepository watchlistItemRepository,
                               StockRepository stockRepository,
-                              StockService stockService) {
+                              StockService stockService,
+                              TrackedStockRepository trackedStockRepository) {
         this.portfolioRepository = portfolioRepository;
         this.holdingRepository = holdingRepository;
         this.transactionRepository = transactionRepository;
@@ -55,6 +59,7 @@ public class DemoSessionService {
         this.watchlistItemRepository = watchlistItemRepository;
         this.stockRepository = stockRepository;
         this.stockService = stockService;
+        this.trackedStockRepository = trackedStockRepository;
     }
 
     public DemoSession createSession(com.github.fabianjim.portfoliomonitor.model.User user) {
@@ -157,6 +162,7 @@ public class DemoSessionService {
             for (Holding holding : aggregated) {
                 double price = tickerPrices.get(holding.getTicker());
                 recordBuyTransaction(session, user, holding.getTicker(), holding.getShares(), price, holding.getBuyTimestamp(), true);
+                startTrackingStock(holding.getTicker());
             }
         }
     }
@@ -184,6 +190,7 @@ public class DemoSessionService {
                 newHolding.setBuyTimestamp(timestamp);
             }
             portfolio.getHoldings().add(newHolding);
+            startTrackingStock(ticker);
         }
 
         session.setRemainingTrades(session.getRemainingTrades() - 1);
@@ -208,6 +215,7 @@ public class DemoSessionService {
         double currentPrice = (price != null && price > 0) ? price : fetchTransactionPrice(ticker);
 
         portfolio.getHoldings().remove(holding);
+        stopTrackingStock(ticker);
         session.setRemainingTrades(session.getRemainingTrades() - 1);
         recordSellTransaction(session, user, ticker, shares, currentPrice, timestamp);
     }
@@ -235,6 +243,7 @@ public class DemoSessionService {
 
         if (sharesToSell == holding.getShares()) {
             portfolio.getHoldings().remove(holding);
+            stopTrackingStock(ticker);
         } else {
             holding.setShares(holding.getShares() - sharesToSell);
         }
@@ -274,6 +283,33 @@ public class DemoSessionService {
             }
         }
         throw new PriceFetchException(ticker, lastError.getMessage(), lastError);
+    }
+
+    private void startTrackingStock(String ticker) {
+        TrackedStock trackedStock = trackedStockRepository.findByTicker(ticker)
+            .orElse(null);
+
+        if (trackedStock == null) {
+            trackedStock = new TrackedStock(ticker);
+            trackedStockRepository.save(trackedStock);
+        } else {
+            trackedStock.incrementHolderCount();
+            trackedStockRepository.save(trackedStock);
+        }
+    }
+
+    private void stopTrackingStock(String ticker) {
+        TrackedStock trackedStock = trackedStockRepository.findByTicker(ticker)
+            .orElse(null);
+
+        if (trackedStock != null) {
+            trackedStock.decrementHolderCount();
+            if (trackedStock.getHolderCount() <= 0) {
+                trackedStockRepository.delete(trackedStock);
+            } else {
+                trackedStockRepository.save(trackedStock);
+            }
+        }
     }
 
     private Transaction recordBuyTransaction(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, String ticker, double shares, double price, Instant timestamp, boolean isInitial) {

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/service/ScheduledStockService.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/service/ScheduledStockService.java
@@ -1,9 +1,11 @@
 package com.github.fabianjim.portfoliomonitor.service;
 
+import com.github.fabianjim.portfoliomonitor.event.PriceFetchCompletedEvent;
 import com.github.fabianjim.portfoliomonitor.model.Stock;
 import com.github.fabianjim.portfoliomonitor.model.Stock.StockType;
 import com.github.fabianjim.portfoliomonitor.model.TrackedStock;
 import com.github.fabianjim.portfoliomonitor.repository.TrackedStockRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -22,10 +24,13 @@ public class ScheduledStockService {
 
     private final StockService stockService;
     private final TrackedStockRepository trackedStockRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
-    public ScheduledStockService(StockService stockService, TrackedStockRepository trackedStockRepository) {
+    public ScheduledStockService(StockService stockService, TrackedStockRepository trackedStockRepository,
+                                 ApplicationEventPublisher eventPublisher) {
         this.stockService = stockService;
         this.trackedStockRepository = trackedStockRepository;
+        this.eventPublisher = eventPublisher;
     }
 
     /**
@@ -56,6 +61,7 @@ public class ScheduledStockService {
             }
 
             logger.info("Completed intraday fetch for " + tickers.size() + " stocks");
+            eventPublisher.publishEvent(new PriceFetchCompletedEvent(Instant.now(), tickers.size(), false));
 
         } catch (Exception e) {
             logger.severe("Error during scheduled intraday stock fetch: " + e.getMessage());
@@ -90,6 +96,7 @@ public class ScheduledStockService {
             }
 
             logger.info("Completed EOD fetch for " + tickers.size() + " stocks");
+            eventPublisher.publishEvent(new PriceFetchCompletedEvent(Instant.now(), tickers.size(), true));
 
         } catch (Exception e) {
             logger.severe("Error during scheduled EOD stock fetch: " + e.getMessage());

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/config/DemoSessionCleanupListenerTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/config/DemoSessionCleanupListenerTest.java
@@ -1,0 +1,75 @@
+package com.github.fabianjim.portfoliomonitor.config;
+
+import com.github.fabianjim.portfoliomonitor.model.DemoSession;
+import com.github.fabianjim.portfoliomonitor.model.Holding;
+import com.github.fabianjim.portfoliomonitor.model.Portfolio;
+import com.github.fabianjim.portfoliomonitor.model.TrackedStock;
+import com.github.fabianjim.portfoliomonitor.repository.TrackedStockRepository;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionResolver;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSessionEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class DemoSessionCleanupListenerTest {
+
+    @Mock
+    private TrackedStockRepository trackedStockRepository;
+
+    @Mock
+    private HttpSessionEvent event;
+
+    @Mock
+    private HttpSession session;
+
+    @InjectMocks
+    private DemoSessionCleanupListener listener;
+
+    @Test
+    void sessionDestroyedCleansUpDemoTrackedStocks() {
+        DemoSession demoSession = new DemoSession();
+        Portfolio portfolio = new Portfolio();
+        portfolio.setHoldings(new ArrayList<>(List.of(
+            new Holding("AAPL", 10),
+            new Holding("TSLA", 5)
+        )));
+        demoSession.setPortfolio(portfolio);
+
+        when(event.getSession()).thenReturn(session);
+        when(session.getAttribute(DemoSessionResolver.DEMO_SESSION_KEY)).thenReturn(demoSession);
+
+        TrackedStock aaplTracked = new TrackedStock("AAPL");
+        aaplTracked.setHolderCount(1);
+        TrackedStock tslaTracked = new TrackedStock("TSLA");
+        tslaTracked.setHolderCount(2);
+
+        when(trackedStockRepository.findByTicker("AAPL")).thenReturn(Optional.of(aaplTracked));
+        when(trackedStockRepository.findByTicker("TSLA")).thenReturn(Optional.of(tslaTracked));
+
+        listener.sessionDestroyed(event);
+
+        verify(trackedStockRepository).delete(aaplTracked);
+        verify(trackedStockRepository).save(tslaTracked);
+        assert tslaTracked.getHolderCount() == 1;
+    }
+
+    @Test
+    void sessionDestroyedDoesNothingWithoutDemoSession() {
+        when(event.getSession()).thenReturn(session);
+        when(session.getAttribute(DemoSessionResolver.DEMO_SESSION_KEY)).thenReturn(null);
+
+        listener.sessionDestroyed(event);
+
+        verifyNoInteractions(trackedStockRepository);
+    }
+}

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/controller/EventControllerTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/controller/EventControllerTest.java
@@ -1,0 +1,33 @@
+package com.github.fabianjim.portfoliomonitor.controller;
+
+import com.github.fabianjim.portfoliomonitor.event.PriceFetchEventService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(EventController.class)
+class EventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PriceFetchEventService priceFetchEventService;
+
+    @Test
+    @WithMockUser(username = "testuser")
+    void subscribeReturnsSseStream() throws Exception {
+        when(priceFetchEventService.subscribe()).thenReturn(new SseEmitter(30_000L));
+
+        mockMvc.perform(get("/api/events"))
+            .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/controller/JournalEntryControllerTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/controller/JournalEntryControllerTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fabianjim.portfoliomonitor.model.JournalEntry;
 import com.github.fabianjim.portfoliomonitor.model.JournalEntryType;
 import com.github.fabianjim.portfoliomonitor.model.User;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionResolver;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionService;
 import com.github.fabianjim.portfoliomonitor.service.JournalEntryService;
 import com.github.fabianjim.portfoliomonitor.service.UserService;
 
@@ -36,6 +38,12 @@ public class JournalEntryControllerTest {
 
     @MockitoBean
     private JournalEntryService journalEntryService;
+
+    @MockitoBean
+    private DemoSessionResolver demoSessionResolver;
+
+    @MockitoBean
+    private DemoSessionService demoSessionService;
 
     @MockitoBean
     private UserService userService;

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/controller/WatchlistControllerTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/controller/WatchlistControllerTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fabianjim.portfoliomonitor.model.StockMetadata;
 import com.github.fabianjim.portfoliomonitor.model.User;
 import com.github.fabianjim.portfoliomonitor.model.WatchlistItem;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionResolver;
+import com.github.fabianjim.portfoliomonitor.service.DemoSessionService;
 import com.github.fabianjim.portfoliomonitor.service.NasdaqMetadataService;
 import com.github.fabianjim.portfoliomonitor.service.UserService;
 import com.github.fabianjim.portfoliomonitor.service.WatchlistService;
@@ -36,6 +38,12 @@ public class WatchlistControllerTest {
 
     @MockitoBean
     private NasdaqMetadataService nasdaqMetadataService;
+
+    @MockitoBean
+    private DemoSessionResolver demoSessionResolver;
+
+    @MockitoBean
+    private DemoSessionService demoSessionService;
 
     @MockitoBean
     private UserService userService;

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/event/PriceFetchEventServiceTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/event/PriceFetchEventServiceTest.java
@@ -1,0 +1,56 @@
+package com.github.fabianjim.portfoliomonitor.event;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PriceFetchEventServiceTest {
+
+    private final PriceFetchEventService priceFetchEventService = new PriceFetchEventService();
+
+    @Test
+    void subscribeReturnsEmitter() {
+        SseEmitter emitter = priceFetchEventService.subscribe();
+        assertNotNull(emitter);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void eventIsBroadcastToSubscribers() throws Exception {
+        AtomicInteger sendCount = new AtomicInteger(0);
+        SseEmitter countingEmitter = new SseEmitter(30_000L) {
+            @Override
+            public void send(SseEventBuilder builder) throws IOException {
+                sendCount.incrementAndGet();
+                super.send(builder);
+            }
+        };
+
+        Field emittersField = PriceFetchEventService.class.getDeclaredField("emitters");
+        emittersField.setAccessible(true);
+        List<SseEmitter> emitters = (List<SseEmitter>) emittersField.get(priceFetchEventService);
+        emitters.add(countingEmitter);
+
+        priceFetchEventService.handlePriceFetchCompleted(
+            new PriceFetchCompletedEvent(Instant.now(), 2, false));
+
+        assertEquals(1, sendCount.get());
+    }
+
+    @Test
+    void payloadExposesExpectedFields() {
+        PriceFetchEventService.PriceFetchCompletedPayload payload =
+            new PriceFetchEventService.PriceFetchCompletedPayload("2026-06-16T12:00:00Z", 3, true);
+
+        assertEquals("2026-06-16T12:00:00Z", payload.getTimestamp());
+        assertEquals(3, payload.getTickerCount());
+        assertTrue(payload.isEod());
+    }
+}

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionServiceTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionServiceTest.java
@@ -11,10 +11,12 @@ import com.github.fabianjim.portfoliomonitor.model.Stock;
 import com.github.fabianjim.portfoliomonitor.model.Transaction;
 import com.github.fabianjim.portfoliomonitor.model.User;
 import com.github.fabianjim.portfoliomonitor.model.WatchlistItem;
+import com.github.fabianjim.portfoliomonitor.model.TrackedStock;
 import com.github.fabianjim.portfoliomonitor.repository.HoldingRepository;
 import com.github.fabianjim.portfoliomonitor.repository.JournalEntryRepository;
 import com.github.fabianjim.portfoliomonitor.repository.PortfolioRepository;
 import com.github.fabianjim.portfoliomonitor.repository.StockRepository;
+import com.github.fabianjim.portfoliomonitor.repository.TrackedStockRepository;
 import com.github.fabianjim.portfoliomonitor.repository.TransactionRepository;
 import com.github.fabianjim.portfoliomonitor.repository.WatchlistItemRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +53,8 @@ public class DemoSessionServiceTest {
     private StockRepository stockRepository;
     @Mock
     private StockService stockService;
+    @Mock
+    private TrackedStockRepository trackedStockRepository;
 
     @InjectMocks
     private DemoSessionService demoSessionService;
@@ -119,6 +123,8 @@ public class DemoSessionServiceTest {
 
         Stock stock = new Stock("META", Instant.now(), 300.0, 295.0, 290.0, 305.0, 294.0, Stock.StockType.INITIAL, Instant.now());
         when(stockService.updateStockData("META", Stock.StockType.INITIAL)).thenReturn(stock);
+        when(trackedStockRepository.findByTicker("META")).thenReturn(Optional.empty());
+        when(trackedStockRepository.save(any(TrackedStock.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         demoSessionService.addHolding(session, demoUser, "META", 5, null, null);
 
@@ -128,6 +134,7 @@ public class DemoSessionServiceTest {
         assertEquals(5, portfolio.getHoldings().get(0).getShares());
         assertEquals(1, session.getTransactions().size());
         assertEquals(300.0, session.getTransactions().get(0).getPrice());
+        verify(trackedStockRepository).save(any(TrackedStock.class));
     }
 
     @Test
@@ -142,7 +149,10 @@ public class DemoSessionServiceTest {
         session.setPortfolio(portfolio);
 
         Stock stock = new Stock("NVDA", Instant.now(), 200.0, 195.0, 190.0, 205.0, 194.0, Stock.StockType.INITIAL, Instant.now());
+        TrackedStock tracked = new TrackedStock("NVDA");
+        tracked.setHolderCount(1);
         when(stockService.updateStockData("NVDA", Stock.StockType.INITIAL)).thenReturn(stock);
+        when(trackedStockRepository.findByTicker("NVDA")).thenReturn(Optional.of(tracked));
 
         demoSessionService.sellHolding(session, demoUser, "NVDA", 10, null, null);
 
@@ -150,6 +160,7 @@ public class DemoSessionServiceTest {
         assertTrue(portfolio.getHoldings().isEmpty());
         assertEquals(1, session.getTransactions().size());
         assertEquals(Transaction.TransactionType.SELL, session.getTransactions().get(0).getType());
+        verify(trackedStockRepository).delete(tracked);
     }
 
     @Test
@@ -163,6 +174,8 @@ public class DemoSessionServiceTest {
 
         Stock stock = new Stock("AAPL", Instant.now(), 150.0, 145.0, 140.0, 155.0, 144.0, Stock.StockType.INITIAL, Instant.now());
         when(stockService.updateStockData("AAPL", Stock.StockType.INITIAL)).thenReturn(stock);
+        when(trackedStockRepository.findByTicker("AAPL")).thenReturn(Optional.empty());
+        when(trackedStockRepository.save(any(TrackedStock.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         demoSessionService.addHolding(session, demoUser, "AAPL", 1, null, null);
         demoSessionService.addHolding(session, demoUser, "AAPL", 1, null, null);
@@ -235,5 +248,52 @@ public class DemoSessionServiceTest {
 
         assertEquals(100.0, summary.getUnrealizedPnL(), 0.001);
         assertEquals(10.0, summary.getUnrealizedPnLPercent(), 0.001);
+    }
+
+    @Test
+    void addHoldingIncrementsExistingTrackedStock() {
+        DemoSession session = new DemoSession();
+        Portfolio portfolio = new Portfolio();
+        portfolio.setId(session.nextId());
+        portfolio.setUser(demoUser);
+        portfolio.setHoldings(new ArrayList<>());
+        session.setPortfolio(portfolio);
+
+        Stock stock = new Stock("TSLA", Instant.now(), 250.0, 245.0, 240.0, 255.0, 244.0, Stock.StockType.INITIAL, Instant.now());
+        TrackedStock tracked = new TrackedStock("TSLA");
+        tracked.setHolderCount(2);
+        when(stockService.updateStockData("TSLA", Stock.StockType.INITIAL)).thenReturn(stock);
+        when(trackedStockRepository.findByTicker("TSLA")).thenReturn(Optional.of(tracked));
+        when(trackedStockRepository.save(tracked)).thenReturn(tracked);
+
+        demoSessionService.addHolding(session, demoUser, "TSLA", 2, null, null);
+
+        assertEquals(3, tracked.getHolderCount());
+        verify(trackedStockRepository).save(tracked);
+    }
+
+    @Test
+    void removeHoldingDecrementsTrackedStock() {
+        DemoSession session = new DemoSession();
+        Portfolio portfolio = new Portfolio();
+        portfolio.setId(session.nextId());
+        portfolio.setUser(demoUser);
+        Holding holding = new Holding("MSFT", 5);
+        holding.setId(session.nextId());
+        portfolio.setHoldings(new ArrayList<>(List.of(holding)));
+        session.setPortfolio(portfolio);
+
+        Stock stock = new Stock("MSFT", Instant.now(), 400.0, 395.0, 390.0, 405.0, 394.0, Stock.StockType.INITIAL, Instant.now());
+        TrackedStock tracked = new TrackedStock("MSFT");
+        tracked.setHolderCount(2);
+        when(stockService.updateStockData("MSFT", Stock.StockType.INITIAL)).thenReturn(stock);
+        when(trackedStockRepository.findByTicker("MSFT")).thenReturn(Optional.of(tracked));
+        when(trackedStockRepository.save(tracked)).thenReturn(tracked);
+
+        demoSessionService.removeHolding(session, demoUser, "MSFT", null, null);
+
+        assertEquals(1, tracked.getHolderCount());
+        verify(trackedStockRepository).save(tracked);
+        verify(trackedStockRepository, never()).delete(any(TrackedStock.class));
     }
 }

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionServiceTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionServiceTest.java
@@ -1,0 +1,239 @@
+package com.github.fabianjim.portfoliomonitor.service;
+
+import com.github.fabianjim.portfoliomonitor.dto.PnLSummaryDTO;
+import com.github.fabianjim.portfoliomonitor.exception.DemoTradeLimitExceededException;
+import com.github.fabianjim.portfoliomonitor.model.DemoSession;
+import com.github.fabianjim.portfoliomonitor.model.Holding;
+import com.github.fabianjim.portfoliomonitor.model.JournalEntry;
+import com.github.fabianjim.portfoliomonitor.model.JournalEntryType;
+import com.github.fabianjim.portfoliomonitor.model.Portfolio;
+import com.github.fabianjim.portfoliomonitor.model.Stock;
+import com.github.fabianjim.portfoliomonitor.model.Transaction;
+import com.github.fabianjim.portfoliomonitor.model.User;
+import com.github.fabianjim.portfoliomonitor.model.WatchlistItem;
+import com.github.fabianjim.portfoliomonitor.repository.HoldingRepository;
+import com.github.fabianjim.portfoliomonitor.repository.JournalEntryRepository;
+import com.github.fabianjim.portfoliomonitor.repository.PortfolioRepository;
+import com.github.fabianjim.portfoliomonitor.repository.StockRepository;
+import com.github.fabianjim.portfoliomonitor.repository.TransactionRepository;
+import com.github.fabianjim.portfoliomonitor.repository.WatchlistItemRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class DemoSessionServiceTest {
+
+    @Mock
+    private PortfolioRepository portfolioRepository;
+    @Mock
+    private HoldingRepository holdingRepository;
+    @Mock
+    private TransactionRepository transactionRepository;
+    @Mock
+    private JournalEntryRepository journalEntryRepository;
+    @Mock
+    private WatchlistItemRepository watchlistItemRepository;
+    @Mock
+    private StockRepository stockRepository;
+    @Mock
+    private StockService stockService;
+
+    @InjectMocks
+    private DemoSessionService demoSessionService;
+
+    private User demoUser;
+
+    @BeforeEach
+    void setUp() {
+        demoUser = new User();
+        demoUser.setId(5);
+        demoUser.setUsername("demo");
+        demoUser.setDemo(true);
+    }
+
+    @Test
+    void createSessionCopiesPortfolioHoldingsTransactionsJournalAndWatchlist() {
+        Portfolio portfolio = new Portfolio();
+        portfolio.setId(10);
+        portfolio.setUser(demoUser);
+        Holding holding = new Holding("AAPL", 10);
+        holding.setId(100);
+        holding.setBuyTimestamp(Instant.now());
+        portfolio.setHoldings(new ArrayList<>(List.of(holding)));
+
+        Transaction tx = new Transaction("AAPL", 10, 150.0, Transaction.TransactionType.BUY, true);
+        tx.setId(200);
+
+        JournalEntry entry = new JournalEntry();
+        entry.setId(300);
+        entry.setEntryType(JournalEntryType.INSIGHT);
+        entry.setBody("Insight");
+        entry.setTimestamp(Instant.now());
+
+        WatchlistItem item = new WatchlistItem();
+        item.setId(400);
+        item.setTicker("TSLA");
+        item.setUser(demoUser);
+
+        when(portfolioRepository.findByUserId(demoUser.getId())).thenReturn(Optional.of(portfolio));
+        when(transactionRepository.findByUserIdOrderByTimestampDesc(demoUser.getId())).thenReturn(List.of(tx));
+        when(journalEntryRepository.findByUserIdOrderByTimestampDesc(demoUser.getId())).thenReturn(List.of(entry));
+        when(watchlistItemRepository.findByUserId(demoUser.getId())).thenReturn(List.of(item));
+
+        DemoSession session = demoSessionService.createSession(demoUser);
+
+        assertNotNull(session.getPortfolio());
+        assertEquals(1, session.getPortfolio().getHoldings().size());
+        assertTrue(session.getPortfolio().getHoldings().get(0).getId() < 0);
+        assertEquals(1, session.getTransactions().size());
+        assertTrue(session.getTransactions().get(0).getId() < 0);
+        assertEquals(1, session.getJournalEntries().size());
+        assertTrue(session.getJournalEntries().get(0).getId() < 0);
+        assertEquals(1, session.getWatchlistItems().size());
+        assertTrue(session.getWatchlistItems().get(0).getId() < 0);
+        assertEquals(3, session.getRemainingTrades());
+    }
+
+    @Test
+    void addHoldingDecreasesRemainingTradesAndRecordsTransaction() {
+        DemoSession session = new DemoSession();
+        Portfolio portfolio = new Portfolio();
+        portfolio.setId(session.nextId());
+        portfolio.setUser(demoUser);
+        portfolio.setHoldings(new ArrayList<>());
+        session.setPortfolio(portfolio);
+
+        Stock stock = new Stock("META", Instant.now(), 300.0, 295.0, 290.0, 305.0, 294.0, Stock.StockType.INITIAL, Instant.now());
+        when(stockService.updateStockData("META", Stock.StockType.INITIAL)).thenReturn(stock);
+
+        demoSessionService.addHolding(session, demoUser, "META", 5, null, null);
+
+        assertEquals(2, session.getRemainingTrades());
+        assertEquals(1, portfolio.getHoldings().size());
+        assertEquals("META", portfolio.getHoldings().get(0).getTicker());
+        assertEquals(5, portfolio.getHoldings().get(0).getShares());
+        assertEquals(1, session.getTransactions().size());
+        assertEquals(300.0, session.getTransactions().get(0).getPrice());
+    }
+
+    @Test
+    void sellHoldingRemovesHoldingWhenSellingAllShares() {
+        DemoSession session = new DemoSession();
+        Portfolio portfolio = new Portfolio();
+        portfolio.setId(session.nextId());
+        portfolio.setUser(demoUser);
+        Holding holding = new Holding("NVDA", 10);
+        holding.setId(session.nextId());
+        portfolio.setHoldings(new ArrayList<>(List.of(holding)));
+        session.setPortfolio(portfolio);
+
+        Stock stock = new Stock("NVDA", Instant.now(), 200.0, 195.0, 190.0, 205.0, 194.0, Stock.StockType.INITIAL, Instant.now());
+        when(stockService.updateStockData("NVDA", Stock.StockType.INITIAL)).thenReturn(stock);
+
+        demoSessionService.sellHolding(session, demoUser, "NVDA", 10, null, null);
+
+        assertEquals(2, session.getRemainingTrades());
+        assertTrue(portfolio.getHoldings().isEmpty());
+        assertEquals(1, session.getTransactions().size());
+        assertEquals(Transaction.TransactionType.SELL, session.getTransactions().get(0).getType());
+    }
+
+    @Test
+    void tradeLimitIsEnforced() {
+        DemoSession session = new DemoSession();
+        Portfolio portfolio = new Portfolio();
+        portfolio.setId(session.nextId());
+        portfolio.setUser(demoUser);
+        portfolio.setHoldings(new ArrayList<>());
+        session.setPortfolio(portfolio);
+
+        Stock stock = new Stock("AAPL", Instant.now(), 150.0, 145.0, 140.0, 155.0, 144.0, Stock.StockType.INITIAL, Instant.now());
+        when(stockService.updateStockData("AAPL", Stock.StockType.INITIAL)).thenReturn(stock);
+
+        demoSessionService.addHolding(session, demoUser, "AAPL", 1, null, null);
+        demoSessionService.addHolding(session, demoUser, "AAPL", 1, null, null);
+        demoSessionService.addHolding(session, demoUser, "AAPL", 1, null, null);
+
+        assertEquals(0, session.getRemainingTrades());
+        assertThrows(DemoTradeLimitExceededException.class, () ->
+            demoSessionService.addHolding(session, demoUser, "AAPL", 1, null, null));
+    }
+
+    @Test
+    void journalEntryCrudWorksInSession() {
+        DemoSession session = new DemoSession();
+        session.setJournalEntries(new ArrayList<>());
+
+        JournalEntry entry = new JournalEntry();
+        entry.setEntryType(JournalEntryType.BUY);
+        entry.setBody("Test entry");
+        entry.setTicker("AAPL");
+
+        when(stockService.getLatestStockData("AAPL")).thenReturn(Optional.empty());
+
+        JournalEntry created = demoSessionService.createJournalEntry(session, demoUser, entry);
+        assertTrue(created.getId() < 0);
+        assertEquals(demoUser, created.getUser());
+
+        List<JournalEntry> entries = demoSessionService.getJournalEntries(session);
+        assertEquals(1, entries.size());
+
+        JournalEntry updated = demoSessionService.updateJournalEntry(session, created.getId(), "Updated");
+        assertEquals("Updated", updated.getBody());
+
+        demoSessionService.deleteJournalEntry(session, created.getId());
+        assertTrue(demoSessionService.getJournalEntries(session).isEmpty());
+    }
+
+    @Test
+    void watchlistCrudWorksInSession() {
+        DemoSession session = new DemoSession();
+        session.setWatchlistItems(new ArrayList<>());
+
+        WatchlistItem added = demoSessionService.addToWatchlist(session, demoUser, "BABA");
+        assertEquals("BABA", added.getTicker());
+        assertTrue(added.getId() < 0);
+
+        List<WatchlistItem> items = demoSessionService.getWatchlistItems(session);
+        assertEquals(1, items.size());
+
+        assertThrows(RuntimeException.class, () -> demoSessionService.addToWatchlist(session, demoUser, "BABA"));
+
+        demoSessionService.removeFromWatchlist(session, "BABA");
+        assertTrue(demoSessionService.getWatchlistItems(session).isEmpty());
+    }
+
+    @Test
+    void getPnLSummaryCalculatesFromSessionTransactions() {
+        DemoSession session = new DemoSession();
+        session.setTransactions(new ArrayList<>());
+
+        Transaction buy = new Transaction("AAPL", 10, 100.0, Transaction.TransactionType.BUY, false);
+        buy.setId(session.nextId());
+        buy.setUser(demoUser);
+        buy.setTotalValue(1000.0);
+        session.getTransactions().add(buy);
+
+        Stock latest = new Stock("AAPL", Instant.now(), 110.0, 105.0, 100.0, 115.0, 104.0, Stock.StockType.INTRADAY, Instant.now());
+        when(stockService.getLatestStockData("AAPL")).thenReturn(Optional.of(latest));
+
+        PnLSummaryDTO summary = demoSessionService.getPnLSummary(session);
+
+        assertEquals(100.0, summary.getUnrealizedPnL(), 0.001);
+        assertEquals(10.0, summary.getUnrealizedPnLPercent(), 0.001);
+    }
+}

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/service/ScheduledStockServiceTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/service/ScheduledStockServiceTest.java
@@ -1,0 +1,76 @@
+package com.github.fabianjim.portfoliomonitor.service;
+
+import com.github.fabianjim.portfoliomonitor.event.PriceFetchCompletedEvent;
+import com.github.fabianjim.portfoliomonitor.model.Stock;
+import com.github.fabianjim.portfoliomonitor.model.TrackedStock;
+import com.github.fabianjim.portfoliomonitor.repository.TrackedStockRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduledStockServiceTest {
+
+    @Mock
+    private StockService stockService;
+
+    @Mock
+    private TrackedStockRepository trackedStockRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private ScheduledStockService scheduledStockService;
+
+    @Test
+    void intradayFetchPublishesCompletionEvent() {
+        when(trackedStockRepository.findAllActiveTickers()).thenReturn(List.of("AAPL", "MSFT"));
+        when(stockService.updateStockData("AAPL", Stock.StockType.INTRADAY)).thenReturn(new Stock());
+        when(stockService.updateStockData("MSFT", Stock.StockType.INTRADAY)).thenReturn(new Stock());
+        when(trackedStockRepository.findByTicker(anyString())).thenReturn(java.util.Optional.of(new TrackedStock()));
+        when(trackedStockRepository.save(any(TrackedStock.class))).thenAnswer(i -> i.getArgument(0));
+
+        scheduledStockService.fetchIntradayStocks();
+
+        ArgumentCaptor<PriceFetchCompletedEvent> captor = ArgumentCaptor.forClass(PriceFetchCompletedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        PriceFetchCompletedEvent event = captor.getValue();
+        assertEquals(2, event.getTickerCount());
+        assertFalse(event.isEod());
+    }
+
+    @Test
+    void eodFetchPublishesCompletionEvent() {
+        when(trackedStockRepository.findAllActiveTickers()).thenReturn(List.of("TSLA"));
+        when(stockService.updateStockData("TSLA", Stock.StockType.EOD)).thenReturn(new Stock());
+        when(trackedStockRepository.findByTicker("TSLA")).thenReturn(java.util.Optional.of(new TrackedStock()));
+        when(trackedStockRepository.save(any(TrackedStock.class))).thenAnswer(i -> i.getArgument(0));
+
+        scheduledStockService.fetchEODStocks();
+
+        ArgumentCaptor<PriceFetchCompletedEvent> captor = ArgumentCaptor.forClass(PriceFetchCompletedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        PriceFetchCompletedEvent event = captor.getValue();
+        assertEquals(1, event.getTickerCount());
+        assertTrue(event.isEod());
+    }
+
+    @Test
+    void noTickersDoesNotPublishEvent() {
+        when(trackedStockRepository.findAllActiveTickers()).thenReturn(List.of());
+
+        scheduledStockService.fetchIntradayStocks();
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+}


### PR DESCRIPTION
- Add landing page with track, reflect, analyze, improve sections using simplified PortfolioChart, JournalEntry, and JournalDetailNodePanel components. Landing page components get their own directory /components/directory.
- Add demo user with assigned holdings and watchlist items. User actions are session based, but adding new holdings does bring the holding through the TrackedStock logic without any distinctive state for demo. Could cause unwanted tracking if a users demo session is not closed properly.
- Implement SSE and event handler specifically for Dashboard portfolio refresh on interval fetches. 