### PR TITLE
Implement Journal page for extended journal entry features

### DIFF
--- a/frontend/vite-project/src/App.tsx
+++ b/frontend/vite-project/src/App.tsx
@@ -8,6 +8,7 @@ import Dashboard from './pages/Dashboard'
 import Analysis from './pages/Analysis'
 import Transactions from './pages/Transactions'
 import VestryInfo from './pages/VestryInfo'
+import Journal from './pages/Journal'
 
 export default function App() {
   return (
@@ -21,6 +22,7 @@ export default function App() {
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/transactions" element={<Transactions />} />
             <Route path="/analysis" element={<Analysis />} />
+            <Route path="/journal" element={<Journal />} />
             <Route path="/vestry-info" element={<VestryInfo />} />
           </Route>
         </Routes>

--- a/frontend/vite-project/src/components/CalendarView.tsx
+++ b/frontend/vite-project/src/components/CalendarView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { ChevronLeftIcon, ChevronRightIcon } from './icons'
 import { journalApi } from '../services/api'
 import type { CalendarDay, JournalFilters } from '../types/journal'
@@ -17,6 +17,19 @@ export default function CalendarView({ onDayClick, activeDate, filters, classNam
   const [dayCounts, setDayCounts] = useState<Record<string, number>>({})
   const [loading, setLoading] = useState(false)
 
+  const countFiltersKey = JSON.stringify([filters?.types, filters?.ticker, filters?.tagIds, filters?.query])
+  const countFilters = useMemo<JournalFilters | undefined>(
+    () =>
+      filters && {
+        types: filters.types,
+        ticker: filters.ticker,
+        tagIds: filters.tagIds,
+        query: filters.query,
+      },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [countFiltersKey]
+  )
+
   useEffect(() => {
     const load = async () => {
       setLoading(true)
@@ -24,7 +37,7 @@ export default function CalendarView({ onDayClick, activeDate, filters, classNam
         const data = (await journalApi.getCalendarEntries(
           currentDate.getFullYear(),
           currentDate.getMonth() + 1,
-          filters
+          countFilters
         )) as CalendarDay[]
         const counts: Record<string, number> = {}
         data.forEach((d) => (counts[d.date] = d.count))
@@ -36,7 +49,7 @@ export default function CalendarView({ onDayClick, activeDate, filters, classNam
       }
     }
     load()
-  }, [currentDate, filters])
+  }, [currentDate, countFilters])
 
   const year = currentDate.getFullYear()
   const month = currentDate.getMonth()

--- a/frontend/vite-project/src/components/CalendarView.tsx
+++ b/frontend/vite-project/src/components/CalendarView.tsx
@@ -1,0 +1,134 @@
+import { useState, useEffect } from 'react'
+import { ChevronLeftIcon, ChevronRightIcon } from './icons'
+import { journalApi } from '../services/api'
+import type { CalendarDay, JournalFilters } from '../types/journal'
+
+interface CalendarViewProps {
+  onDayClick: (date: Date) => void
+  activeDate?: Date | null
+  filters?: JournalFilters
+  className?: string
+}
+
+const WEEK_DAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+
+export default function CalendarView({ onDayClick, activeDate, filters, className = '' }: CalendarViewProps) {
+  const [currentDate, setCurrentDate] = useState(() => new Date())
+  const [dayCounts, setDayCounts] = useState<Record<string, number>>({})
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true)
+      try {
+        const data = (await journalApi.getCalendarEntries(
+          currentDate.getFullYear(),
+          currentDate.getMonth() + 1,
+          filters
+        )) as CalendarDay[]
+        const counts: Record<string, number> = {}
+        data.forEach((d) => (counts[d.date] = d.count))
+        setDayCounts(counts)
+      } catch (e) {
+        console.error('Failed to load calendar:', e)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [currentDate, filters])
+
+  const year = currentDate.getFullYear()
+  const month = currentDate.getMonth()
+
+  const firstDayOfMonth = new Date(year, month, 1)
+  const lastDayOfMonth = new Date(year, month + 1, 0)
+  const daysInMonth = lastDayOfMonth.getDate()
+  const startDayOfWeek = firstDayOfMonth.getDay()
+
+  const days: (number | null)[] = []
+  for (let i = 0; i < startDayOfWeek; i++) days.push(null)
+  for (let i = 1; i <= daysInMonth; i++) days.push(i)
+
+  const padDate = (day: number) => `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+
+  const navigate = (delta: number) => {
+    setCurrentDate((prev) => new Date(prev.getFullYear(), prev.getMonth() + delta, 1))
+  }
+
+  const isActive = (day: number) => {
+    if (!activeDate) return false
+    return (
+      activeDate.getFullYear() === year &&
+      activeDate.getMonth() === month &&
+      activeDate.getDate() === day
+    )
+  }
+
+  const maxCount = Math.max(...Object.values(dayCounts), 1)
+
+  return (
+    <div className={`p-4 bg-surface rounded-lg border border-border ${className}`}>
+      <div className="flex items-center justify-between mb-4">
+        <button
+          onClick={() => navigate(-1)}
+          className="p-1 rounded-md hover:bg-surface-hover text-secondary hover:text-foreground transition-colors"
+          aria-label="Previous month"
+        >
+          <ChevronLeftIcon className="w-5 h-5" />
+        </button>
+        <span className="text-foreground font-130">
+          {currentDate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+        </span>
+        <button
+          onClick={() => navigate(1)}
+          className="p-1 rounded-md hover:bg-surface-hover text-secondary hover:text-foreground transition-colors"
+          aria-label="Next month"
+        >
+          <ChevronRightIcon className="w-5 h-5" />
+        </button>
+      </div>
+
+      {loading && Object.keys(dayCounts).length === 0 && (
+        <div className="text-sm text-muted">Loading calendar...</div>
+      )}
+
+      <div className="grid grid-cols-7 gap-1 text-center">
+        {WEEK_DAYS.map((d) => (
+          <div key={d} className="text-xs text-muted py-1">{d}</div>
+        ))}
+        {days.map((day, idx) => {
+          if (!day) return <div key={idx} />
+          const dateKey = padDate(day)
+          const count = dayCounts[dateKey] || 0
+          const intensity = count > 0 ? Math.max(0.2, count / maxCount) : 0
+          return (
+            <button
+              key={idx}
+              onClick={() => onDayClick(new Date(year, month, day))}
+              className={`relative aspect-square flex flex-col items-center justify-center rounded-md text-sm transition-colors ${
+                isActive(day)
+                  ? 'ring-2 ring-primary bg-primary/20 text-primary'
+                  : count > 0
+                  ? 'hover:bg-surface-hover text-foreground'
+                  : 'text-secondary hover:bg-surface-hover'
+              }`}
+              style={
+                count > 0 && !isActive(day)
+                  ? { backgroundColor: `rgba(94, 158, 214, ${intensity * 0.35})` }
+                  : undefined
+              }
+            >
+              <span>{day}</span>
+              {count > 0 && (
+                <span className="absolute bottom-0.5 text-[9px] leading-none text-primary">
+                  {count}
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/vite-project/src/components/JournalFilterBar.tsx
+++ b/frontend/vite-project/src/components/JournalFilterBar.tsx
@@ -1,0 +1,146 @@
+import type { Tag, JournalEntryType, JournalFilters } from '../types/journal'
+
+const ENTRY_TYPES: { value: JournalEntryType; label: string }[] = [
+  { value: 'BUY', label: 'Buy' },
+  { value: 'SELL', label: 'Sell' },
+  { value: 'INSIGHT', label: 'Insight' },
+  { value: 'MARKET_EVENT', label: 'Market Event' },
+]
+
+interface JournalFilterBarProps {
+  filters: JournalFilters
+  availableTags: Tag[]
+  onChange: (filters: JournalFilters) => void
+  className?: string
+}
+
+export default function JournalFilterBar({ filters, availableTags, onChange, className = '' }: JournalFilterBarProps) {
+  const update = (updates: Partial<JournalFilters>) => {
+    onChange({ ...filters, ...updates })
+  }
+
+  const toggleType = (type: JournalEntryType) => {
+    const current = filters.types || []
+    if (current.includes(type)) {
+      update({ types: current.filter((t) => t !== type) })
+    } else {
+      update({ types: [...current, type] })
+    }
+  }
+
+  const toggleTag = (tagId: number) => {
+    const current = filters.tagIds || []
+    if (current.includes(tagId)) {
+      update({ tagIds: current.filter((id) => id !== tagId) })
+    } else {
+      update({ tagIds: [...current, tagId] })
+    }
+  }
+
+  const hasActiveFilters =
+    filters.from ||
+    filters.to ||
+    (filters.types && filters.types.length > 0) ||
+    filters.ticker ||
+    (filters.tagIds && filters.tagIds.length > 0) ||
+    filters.query
+
+  return (
+    <div className={`space-y-4 ${className}`}>
+      <div className="flex flex-col sm:flex-row gap-3">
+        <input
+          type="text"
+          placeholder="Search entries..."
+          value={filters.query || ''}
+          onChange={(e) => update({ query: e.target.value || undefined })}
+          className="flex-1 px-2 py-2 bg-surface-hover border border-border rounded-md text-foreground placeholder-muted focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+        />
+        <input
+          type="text"
+          placeholder="Ticker"
+          value={filters.ticker || ''}
+          onChange={(e) => update({ ticker: e.target.value.toUpperCase() || undefined })}
+          className="w-full sm:w-32 px-2 py-2 bg-surface-hover border border-border rounded-md text-foreground placeholder-muted focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+        />
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-muted whitespace-nowrap">From:</label>
+          <input
+            type="date"
+            value={filters.from ? filters.from.substring(0, 10) : ''}
+            onChange={(e) => update({ from: e.target.value ? new Date(e.target.value).toISOString() : undefined })}
+            className="px-2 py-2 bg-surface-hover border border-border rounded-md text-foreground focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-muted whitespace-nowrap">To:</label>
+          <input
+            type="date"
+            value={filters.to ? filters.to.substring(0, 10) : ''}
+            onChange={(e) => update({ to: e.target.value ? new Date(e.target.value).toISOString() : undefined })}
+            className="px-2 py-2 bg-surface-hover border border-border rounded-md text-foreground focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {ENTRY_TYPES.map((type) => (
+          <button
+            key={type.value}
+            type="button"
+            onClick={() => toggleType(type.value)}
+            className={`px-2.5 py-1 text-xs rounded-md border transition-colors ${
+              filters.types?.includes(type.value)
+                ? 'bg-primary/20 border-primary text-primary'
+                : 'bg-surface-hover border-border text-secondary hover:text-foreground'
+            }`}
+          >
+            {type.label}
+          </button>
+        ))}
+      </div>
+
+      {availableTags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {availableTags.map((tag) => (
+            <button
+              key={tag.id}
+              type="button"
+              onClick={() => toggleTag(tag.id)}
+              className={`px-2.5 py-1 text-xs rounded-full border transition-colors ${
+                filters.tagIds?.includes(tag.id)
+                  ? 'text-foreground'
+                  : 'bg-surface-hover text-secondary hover:text-foreground'
+              }`}
+              style={
+                filters.tagIds?.includes(tag.id)
+                  ? {
+                      backgroundColor: `${tag.color}25`,
+                      borderColor: `${tag.color}50`,
+                      color: tag.color,
+                    }
+                  : undefined
+              }
+            >
+              #{tag.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {hasActiveFilters && (
+        <button
+          type="button"
+          onClick={() =>
+            onChange({})
+          }
+          className="text-sm text-secondary hover:text-foreground underline"
+        >
+          Clear filters
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/vite-project/src/components/JournalPanel.tsx
+++ b/frontend/vite-project/src/components/JournalPanel.tsx
@@ -2,6 +2,9 @@ import { useState, useEffect, useRef, forwardRef, useImperativeHandle } from 're
 import type { JournalEntry, JournalEntryType } from '../types/journal'
 import { journalApi } from '../services/api'
 import { formatDateTime, isTradingHours } from '../utils/dateUtils'
+import { getDisplayBody, parseTagsFromBody } from '../utils/tagUtils'
+import TagInput from './TagInput'
+import TagPills from './TagPills'
 
 export interface JournalPanelHandle {
   scrollToEntry: (id: number) => void
@@ -87,12 +90,15 @@ const JournalPanel = forwardRef<JournalPanelHandle, JournalPanelProps>(function 
       return
     }
 
+    const { body: finalBody, tags } = parseTagsFromBody(body)
+
     setLoading(true)
     try {
       await journalApi.createEntry({
         entryType,
-        body: body.trim(),
+        body: finalBody,
         ticker: ticker.trim().toUpperCase() || null,
+        tags,
       })
       setBody('')
       setTicker('')
@@ -117,9 +123,11 @@ const JournalPanel = forwardRef<JournalPanelHandle, JournalPanelProps>(function 
       setEntryError('Please enter a note')
       return
     }
+    const { body: finalBody, tags } = parseTagsFromBody(editBody)
+
     setLoading(true)
     try {
-      await journalApi.updateEntry(entryId, editBody.trim())
+      await journalApi.updateEntry(entryId, { body: finalBody, tags })
       setEditingEntryId(null)
       setEditBody('')
       await fetchEntries()
@@ -204,12 +212,12 @@ const JournalPanel = forwardRef<JournalPanelHandle, JournalPanelProps>(function 
         />
       </div>
 
-      <textarea
+      <TagInput
         value={body}
-        onChange={(e) => setBody(e.target.value)}
+        onChange={setBody}
         placeholder="Write your thoughts..."
         rows={3}
-        className="w-full px-2 py-2 bg-surface-hover border border-border rounded-md text-foreground resize-y focus:outline-none focus:ring-2 focus:ring-primary mb-3"
+        className="mb-3"
       />
 
       <div className="flex gap-2 mb-4">
@@ -255,12 +263,11 @@ const JournalPanel = forwardRef<JournalPanelHandle, JournalPanelProps>(function 
               )}
               {editingEntryId === entry.id ? (
                 <div>
-                  <textarea
+                  <TagInput
                     value={editBody}
-                    onChange={(e) => setEditBody(e.target.value)}
+                    onChange={setEditBody}
                     rows={3}
-                    className="w-full px-2 py-1 bg-transparent text-sm text-foreground resize-none border-none outline-none focus:outline-none focus-visible:outline-none focus-visible:ring-0"
-                    autoFocus
+                    className="bg-transparent text-sm text-foreground border-none focus:ring-0 resize-none"
                   />
                   <div className="flex gap-2 mt-2">
                     <button
@@ -283,7 +290,8 @@ const JournalPanel = forwardRef<JournalPanelHandle, JournalPanelProps>(function 
                 </div>
               ) : (
                 <>
-                  <div className="text-sm text-foreground whitespace-pre-wrap">{entry.body}</div>
+                  <div className="text-sm text-foreground whitespace-pre-wrap">{getDisplayBody(entry.body)}</div>
+                  <TagPills tags={entry.tags} />
                   <div className="absolute bottom-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                     {(entry.entryType === 'BUY' || entry.entryType === 'SELL') && isTradingHours(entry.timestamp) && (
                       <button

--- a/frontend/vite-project/src/components/Layout.tsx
+++ b/frontend/vite-project/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import {
   ChartPieIcon,
   DocumentCurrencyDollarIcon,
   QuestionMarkCircleIcon,
+  BookOpenIcon,
   LogoutIcon,
   GithubIcon,
   ExclamationCircleIcon,
@@ -18,6 +19,7 @@ const navItems = [
   { path: '/dashboard', label: 'Dashboard', icon: HomeIcon },
   { path: '/analysis', label: 'Holding Analysis', icon: ChartPieIcon },
   { path: '/transactions', label: 'Transactions', icon: DocumentCurrencyDollarIcon },
+  { path: '/journal', label: 'Journal', icon: BookOpenIcon },
   { path: '/vestry-info', label: 'Vestry Info', icon: QuestionMarkCircleIcon },
 ]
 

--- a/frontend/vite-project/src/components/TagInput.tsx
+++ b/frontend/vite-project/src/components/TagInput.tsx
@@ -1,0 +1,200 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+import { journalApi } from '../services/api'
+import { getActiveTagQuery } from '../utils/tagUtils'
+import type { Tag } from '../types/journal'
+
+interface TagInputProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  rows?: number
+  className?: string
+}
+
+export default function TagInput({
+  value,
+  onChange,
+  placeholder,
+  rows = 3,
+  className = '',
+}: TagInputProps) {
+  const [suggestions, setSuggestions] = useState<Tag[]>([])
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const [popupPosition, setPopupPosition] = useState({ top: 0, left: 0 })
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const popupRef = useRef<HTMLDivElement | null>(null)
+  const debounceRef = useRef<number | null>(null)
+
+  const fetchSuggestions = useCallback((query: string) => {
+    if (debounceRef.current) window.clearTimeout(debounceRef.current)
+    debounceRef.current = window.setTimeout(async () => {
+      try {
+        const data = (await journalApi.getPopularTags(query)) as Tag[]
+        setSuggestions(data || [])
+        setSelectedIndex(0)
+        setShowSuggestions(true)
+      } catch {
+        setSuggestions([])
+        setShowSuggestions(false)
+      }
+    }, 150)
+  }, [])
+
+  const getCursorCoordinates = (textarea: HTMLTextAreaElement, position: number) => {
+    const style = window.getComputedStyle(textarea)
+    const div = document.createElement('div')
+
+    const stylesToCopy = [
+      'fontFamily', 'fontSize', 'fontWeight', 'lineHeight', 'letterSpacing',
+      'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft',
+      'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth',
+      'boxSizing', 'whiteSpace', 'wordWrap', 'overflow',
+    ]
+    stylesToCopy.forEach((prop) => div.style.setProperty(prop, style.getPropertyValue(prop)))
+
+    div.style.position = 'absolute'
+    div.style.visibility = 'hidden'
+    div.style.width = textarea.clientWidth + 'px'
+    div.style.height = 'auto'
+    div.style.whiteSpace = 'pre-wrap'
+    div.style.wordWrap = 'break-word'
+
+    const text = textarea.value.substring(0, position)
+    const span = document.createElement('span')
+    span.textContent = text
+    div.appendChild(span)
+
+    const marker = document.createElement('span')
+    marker.textContent = '|'
+    div.appendChild(marker)
+
+    document.body.appendChild(div)
+    const markerRect = marker.getBoundingClientRect()
+    const textareaRect = textarea.getBoundingClientRect()
+    document.body.removeChild(div)
+
+    return {
+      top: markerRect.top - textareaRect.top + textarea.scrollTop,
+      left: markerRect.left - textareaRect.left,
+    }
+  }
+
+  const checkSuggestions = useCallback((textarea: HTMLTextAreaElement, currentValue: string) => {
+    const cursorPosition = textarea.selectionStart
+    const { query, startIndex } = getActiveTagQuery(currentValue, cursorPosition)
+
+    if (query !== null) {
+      setPopupPosition(getCursorCoordinates(textarea, startIndex))
+      fetchSuggestions(query)
+    } else {
+      setShowSuggestions(false)
+    }
+  }, [fetchSuggestions])
+
+  const insertSuggestion = (suggestion: Tag) => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+
+    const cursorPosition = textarea.selectionStart
+    const { startIndex } = getActiveTagQuery(value, cursorPosition)
+    if (startIndex === -1) return
+
+    const before = value.substring(0, startIndex)
+    const after = value.substring(cursorPosition)
+    const newValue = `${before}#${suggestion.name} ${after}`
+    onChange(newValue)
+
+    window.setTimeout(() => {
+      const newCursorPosition = startIndex + suggestion.name.length + 2
+      textarea.setSelectionRange(newCursorPosition, newCursorPosition)
+      textarea.focus()
+    }, 0)
+
+    setShowSuggestions(false)
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value
+    onChange(newValue)
+    checkSuggestions(e.target, newValue)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!showSuggestions || suggestions.length === 0) return
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setSelectedIndex((prev) => (prev + 1) % suggestions.length)
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setSelectedIndex((prev) => (prev - 1 + suggestions.length) % suggestions.length)
+    } else if (e.key === 'Enter' || e.key === 'Tab') {
+      e.preventDefault()
+      insertSuggestion(suggestions[selectedIndex])
+    } else if (e.key === 'Escape') {
+      setShowSuggestions(false)
+    }
+  }
+
+  const handleClick = (e: React.MouseEvent<HTMLTextAreaElement>) => {
+    checkSuggestions(e.currentTarget, value)
+  }
+
+  const handleKeyUp = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!['ArrowDown', 'ArrowUp', 'Enter', 'Tab', 'Escape'].includes(e.key)) {
+      checkSuggestions(e.currentTarget, value)
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) window.clearTimeout(debounceRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (popupRef.current && showSuggestions) {
+      const height = popupRef.current.offsetHeight
+      setPopupPosition((prev) => ({ ...prev, top: prev.top - height - 8 }))
+    }
+  }, [showSuggestions, suggestions.length])
+
+  return (
+    <div className="relative">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onClick={handleClick}
+        onKeyUp={handleKeyUp}
+        placeholder={placeholder}
+        rows={rows}
+        className={`w-full px-2 py-2 bg-surface-hover border border-border rounded-md text-foreground resize-y focus:outline-none focus:ring-2 focus:ring-primary ${className}`}
+      />
+      {showSuggestions && suggestions.length > 0 && (
+        <div
+          ref={popupRef}
+          className="absolute z-50 bg-surface border border-border rounded-md shadow-lg py-1 min-w-32"
+          style={{ top: popupPosition.top, left: popupPosition.left }}
+        >
+          {suggestions.map((suggestion, index) => (
+            <button
+              key={suggestion.id}
+              type="button"
+              onClick={() => insertSuggestion(suggestion)}
+              className={`w-full text-left px-3 py-1.5 text-sm transition-colors ${
+                index === selectedIndex
+                  ? 'bg-primary/20 text-primary'
+                  : 'text-foreground hover:bg-surface-hover'
+              }`}
+            >
+              #{suggestion.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/vite-project/src/components/TagPills.tsx
+++ b/frontend/vite-project/src/components/TagPills.tsx
@@ -1,0 +1,34 @@
+import type { Tag } from '../types/journal'
+
+interface TagPillsProps {
+  tags: Tag[]
+  onTagClick?: (tag: Tag) => void
+  className?: string
+}
+
+export default function TagPills({ tags, onTagClick, className = '' }: TagPillsProps) {
+  if (!tags.length) return null
+
+  return (
+    <div className={`flex flex-wrap gap-2 mt-2 ${className}`}>
+      {tags.map((tag) => (
+        <button
+          key={tag.id}
+          type="button"
+          onClick={() => onTagClick?.(tag)}
+          disabled={!onTagClick}
+          className={`px-2.5 py-0.5 rounded-full text-xs font-medium transition-opacity ${
+            onTagClick ? 'hover:opacity-80 cursor-pointer' : 'cursor-default'
+          }`}
+          style={{
+            backgroundColor: tag.color ? `${tag.color}25` : 'rgba(255, 255, 255, 0.1)',
+            color: tag.color || '#bdbdbd',
+            border: `1px solid ${tag.color ? `${tag.color}50` : 'rgba(255, 255, 255, 0.1)'}`,
+          }}
+        >
+          #{tag.name}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/frontend/vite-project/src/components/icons/index.tsx
+++ b/frontend/vite-project/src/components/icons/index.tsx
@@ -75,6 +75,22 @@ export function ChevronDoubleRightIcon({ className = 'w-5 h-5' }: IconProps) {
   )
 }
 
+export function ChevronLeftIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className={className}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+    </svg>
+  )
+}
+
+export function ChevronRightIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className={className}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+    </svg>
+  )
+}
+
 export function Bars3Icon({ className = 'w-5 h-5' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className={className}>
@@ -119,6 +135,14 @@ export function CalendarIcon({ className = 'w-5 h-5' }: IconProps) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className={className}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
+    </svg>
+  )
+}
+
+export function BookOpenIcon({ className = 'w-5 h-5' }: IconProps) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className={className}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A9.902 9.902 0 016 18.75c1.052 0 2.062-.18 3-.512v-14.25c.938.332 1.948.512 3 .512s2.062-.18 3-.512V18.75c.938.332 1.948.512 3 .512.96 0 1.888-.156 2.75-.47V4.262c-.938.332-1.948.512-3 .512-2.186 0-4.236-.584-6-1.608z" />
     </svg>
   )
 }

--- a/frontend/vite-project/src/pages/Dashboard.tsx
+++ b/frontend/vite-project/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { useOutletContext } from 'react-router-dom'
+import { Link, useOutletContext } from 'react-router-dom'
 import PortfolioChart from '../components/PortfolioChart'
 import type { PortfolioChartHandle } from '../components/PortfolioChart'
 import JournalPrompt from '../components/JournalPrompt'
@@ -429,7 +429,12 @@ export default function Dashboard() {
       {/* Holdings Table */}
       {/* Journal Section */}
       <div className="mb-8">
-        <h3 className="text-xl font-150 mt-4 mb-4">Journal</h3>
+        <div className="flex items-center justify-between mt-4 mb-4">
+          <h3 className="text-xl font-150 m-0">Journal</h3>
+          <Link to="/journal" className="text-sm italic text-secondary hover:text-foreground transition-colors">
+            Expand
+          </Link>
+        </div>
         <JournalPanel
           ref={journalPanelRef}
           activeJournalId={activeJournalId}

--- a/frontend/vite-project/src/pages/Journal.tsx
+++ b/frontend/vite-project/src/pages/Journal.tsx
@@ -1,0 +1,424 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import type { JournalEntry, JournalEntryType, JournalFilters, Tag } from '../types/journal'
+import { journalApi } from '../services/api'
+import { formatDateTime } from '../utils/dateUtils'
+import { getDisplayBody, parseTagsFromBody } from '../utils/tagUtils'
+import CalendarView from '../components/CalendarView'
+import JournalFilterBar from '../components/JournalFilterBar'
+import TagInput from '../components/TagInput'
+import TagPills from '../components/TagPills'
+import JournalDetailPanel from '../components/JournalDetailPanel'
+
+export default function JournalPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const [filters, setFilters] = useState<JournalFilters>(() => {
+    const from = searchParams.get('from') || undefined
+    const to = searchParams.get('to') || undefined
+    const types = searchParams.getAll('types') as JournalEntryType[]
+    const ticker = searchParams.get('ticker') || undefined
+    const tagIds = searchParams.getAll('tagIds').map((id) => parseInt(id, 10))
+    const query = searchParams.get('query') || undefined
+    return {
+      from,
+      to,
+      types: types.length > 0 ? types : undefined,
+      ticker,
+      tagIds: tagIds.length > 0 ? tagIds : undefined,
+      query,
+    }
+  })
+
+  const [entries, setEntries] = useState<JournalEntry[]>([])
+  const [allTags, setAllTags] = useState<Tag[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [entryType, setEntryType] = useState<JournalEntryType>('INSIGHT')
+  const [ticker, setTicker] = useState('')
+  const [body, setBody] = useState('')
+  const [showNewEntry, setShowNewEntry] = useState(false)
+  const [selectedEntry, setSelectedEntry] = useState<JournalEntry | null>(null)
+  const [activeDate, setActiveDate] = useState<Date | null>(null)
+  const [editingEntryId, setEditingEntryId] = useState<number | null>(null)
+  const [editBody, setEditBody] = useState('')
+  const [editError, setEditError] = useState('')
+  const listRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    document.title = 'Journal'
+  }, [])
+
+  useEffect(() => {
+    const from = searchParams.get('from') || undefined
+    const to = searchParams.get('to') || undefined
+    const types = searchParams.getAll('types') as JournalEntryType[]
+    const ticker = searchParams.get('ticker') || undefined
+    const tagIds = searchParams.getAll('tagIds').map((id) => parseInt(id, 10))
+    const query = searchParams.get('query') || undefined
+    setFilters({
+      from,
+      to,
+      types: types.length > 0 ? types : undefined,
+      ticker,
+      tagIds: tagIds.length > 0 ? tagIds : undefined,
+      query,
+    })
+  }, [searchParams])
+
+  const fetchEntries = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const hasFilters =
+        filters.from ||
+        filters.to ||
+        filters.types?.length ||
+        filters.ticker ||
+        filters.tagIds?.length ||
+        filters.query
+
+      const data = hasFilters
+        ? ((await journalApi.getFilteredEntries({
+            from: filters.from,
+            to: filters.to,
+            types: filters.types,
+            ticker: filters.ticker,
+            tagIds: filters.tagIds,
+            query: filters.query,
+          })) as JournalEntry[])
+        : ((await journalApi.getEntries()) as JournalEntry[])
+      setEntries(data || [])
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unexpected error'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }, [filters])
+
+  const fetchTags = useCallback(async () => {
+    try {
+      const data = (await journalApi.getPopularTags('')) as Tag[]
+      setAllTags(data || [])
+    } catch (e) {
+      console.error('Failed to fetch tags:', e)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchEntries()
+  }, [fetchEntries])
+
+  useEffect(() => {
+    fetchTags()
+  }, [fetchTags])
+
+  const updateFilters = (newFilters: JournalFilters) => {
+    const params = new URLSearchParams()
+    if (newFilters.from) params.set('from', newFilters.from)
+    if (newFilters.to) params.set('to', newFilters.to)
+    newFilters.types?.forEach((t) => params.append('types', t))
+    if (newFilters.ticker) params.set('ticker', newFilters.ticker)
+    newFilters.tagIds?.forEach((id) => params.append('tagIds', id.toString()))
+    if (newFilters.query) params.set('query', newFilters.query)
+    setSearchParams(params, { replace: true })
+  }
+
+  const handleDayClick = (date: Date) => {
+    const start = new Date(date)
+    start.setHours(0, 0, 0, 0)
+    const end = new Date(date)
+    end.setHours(23, 59, 59, 999)
+    setActiveDate(date)
+    updateFilters({
+      ...filters,
+      from: start.toISOString(),
+      to: end.toISOString(),
+    })
+  }
+
+  const handleSubmit = async () => {
+    if (!body.trim()) {
+      setError('Please enter a note')
+      return
+    }
+    const { body: finalBody, tags } = parseTagsFromBody(body)
+
+    setLoading(true)
+    try {
+      await journalApi.createEntry({
+        entryType,
+        body: finalBody,
+        ticker: ticker.trim().toUpperCase() || null,
+        tags,
+      })
+      setBody('')
+      setTicker('')
+      setEntryType('INSIGHT')
+      setShowNewEntry(false)
+      updateFilters({})
+      await fetchEntries()
+      await fetchTags()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unexpected error'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleEditClick = (entry: JournalEntry) => {
+    setEditingEntryId(entry.id)
+    setEditBody(entry.body)
+    setEditError('')
+  }
+
+  const handleSaveEdit = async (entryId: number) => {
+    if (!editBody.trim()) {
+      setEditError('Please enter a note')
+      return
+    }
+    const { body: finalBody, tags } = parseTagsFromBody(editBody)
+
+    setLoading(true)
+    try {
+      await journalApi.updateEntry(entryId, { body: finalBody, tags })
+      setEditingEntryId(null)
+      setEditBody('')
+      setEditError('')
+      await fetchEntries()
+      await fetchTags()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unexpected error'
+      setEditError(message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleCancelEdit = () => {
+    setEditingEntryId(null)
+    setEditBody('')
+    setEditError('')
+  }
+
+  const handleDelete = async (entryId: number) => {
+    if (!confirm('Delete this entry?')) return
+    setLoading(true)
+    try {
+      await journalApi.deleteEntry(entryId)
+      await fetchEntries()
+      await fetchTags()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unexpected error'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const getTypeColor = (type: JournalEntryType) => {
+    switch (type) {
+      case 'BUY': return 'text-gain'
+      case 'SELL': return 'text-loss'
+      case 'INSIGHT': return 'text-primary'
+      case 'MARKET_EVENT': return 'text-event'
+      default: return 'text-muted'
+    }
+  }
+
+  const getTypeBg = (type: JournalEntryType) => {
+    switch (type) {
+      case 'BUY': return 'bg-gain/10'
+      case 'SELL': return 'bg-loss/10'
+      case 'INSIGHT': return 'bg-primary/10'
+      case 'MARKET_EVENT': return 'bg-secondary/10'
+      default: return 'bg-muted/10'
+    }
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto mt-6 px-3 mb-8">
+      <h2 className="text-2xl font-150 mb-6">Journal</h2>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+        <div className="lg:col-span-2 space-y-3">
+          <div className="flex justify-between items-center">
+            <span className="text-sm text-muted">
+              {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
+            </span>
+            <button
+              onClick={() => setShowNewEntry((prev) => !prev)}
+              className="px-3 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary-hover transition-colors text-sm"
+            >
+              {showNewEntry ? 'Cancel' : 'New Entry'}
+            </button>
+          </div>
+
+          {showNewEntry && (
+            <div className="p-4 bg-surface rounded-lg border border-border space-y-3">
+              <div className="flex gap-3 flex-wrap">
+                <select
+                  value={entryType}
+                  onChange={(e) => setEntryType(e.target.value as JournalEntryType)}
+                  className="px-2 py-2 bg-surface-hover border border-border rounded-md text-foreground focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+                >
+                  <option value="INSIGHT">Insight</option>
+                  <option value="MARKET_EVENT">Market Event</option>
+                  <option value="BUY">Buy</option>
+                  <option value="SELL">Sell</option>
+                </select>
+                <input
+                  type="text"
+                  placeholder="Ticker (optional)"
+                  value={ticker}
+                  onChange={(e) => setTicker(e.target.value.toUpperCase())}
+                  className="px-2 py-2 bg-surface-hover border border-border rounded-md text-foreground placeholder-muted focus:outline-none focus:ring-2 focus:ring-primary text-sm w-32"
+                />
+              </div>
+              <TagInput
+                value={body}
+                onChange={setBody}
+                placeholder="Write your thoughts... Use #tag to add tags"
+                rows={3}
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={handleSubmit}
+                  disabled={loading || !body.trim()}
+                  className="px-3 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary-hover transition-colors disabled:opacity-50"
+                >
+                  {loading ? 'Saving…' : 'Save Entry'}
+                </button>
+              </div>
+              {error && <div className="text-error text-sm">{error}</div>}
+            </div>
+          )}
+
+          <div ref={listRef} className="space-y-3">
+            {loading && entries.length === 0 && (
+              <div className="text-muted">Loading entries...</div>
+            )}
+
+            {entries.length === 0 && !loading && (
+              <div className="text-muted italic">No journal entries match your filters.</div>
+            )}
+
+            {entries.map((entry) => (
+              <div
+                key={entry.id}
+                onClick={() => !editingEntryId && setSelectedEntry(entry)}
+                className={`p-4 bg-surface rounded-lg border border-border cursor-pointer hover:bg-surface-hover transition-colors ${getTypeBg(entry.entryType)}`}
+              >
+                <div className="flex justify-between items-start mb-1">
+                  <div className="flex items-center gap-2">
+                    <span className={`text-xs font-130 uppercase ${getTypeColor(entry.entryType)}`}>
+                      {entry.entryType.replace('_', ' ')}
+                    </span>
+                    {entry.ticker && (
+                      <span className="text-xs font-semibold text-foreground">{entry.ticker}</span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-muted">{formatDateTime(entry.timestamp)}</span>
+                    {editingEntryId !== entry.id && (
+                      <>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleEditClick(entry)
+                          }}
+                          className="text-xs text-primary hover:text-primary-hover px-2 py-1 rounded hover:bg-primary/10 transition-colors"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleDelete(entry.id)
+                          }}
+                          className="text-xs text-error hover:text-error px-2 py-1 rounded hover:bg-error/10 transition-colors"
+                        >
+                          Delete
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+                {entry.priceSnapshot != null && (
+                  <div className="text-xs text-muted mb-1">
+                    Snapshot: ${entry.priceSnapshot.toFixed(2)}
+                  </div>
+                )}
+                {editingEntryId === entry.id ? (
+                  <div onClick={(e) => e.stopPropagation()}>
+                    <TagInput
+                      value={editBody}
+                      onChange={setEditBody}
+                      rows={3}
+                    />
+                    <div className="flex gap-2 mt-2">
+                      <button
+                        onClick={() => handleSaveEdit(entry.id)}
+                        disabled={loading}
+                        className="px-3 py-1.5 bg-primary text-primary-foreground text-xs rounded-md hover:bg-primary-hover transition-colors disabled:opacity-50"
+                      >
+                        {loading ? 'Saving…' : 'Save'}
+                      </button>
+                      <button
+                        onClick={handleCancelEdit}
+                        className="px-3 py-1.5 bg-surface border border-border text-foreground text-xs rounded-md hover:bg-surface-hover transition-colors"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                    {editError && <div className="text-error text-xs mt-1">{editError}</div>}
+                  </div>
+                ) : (
+                  <>
+                    <div className="text-sm text-foreground whitespace-pre-wrap">{getDisplayBody(entry.body)}</div>
+                    <TagPills
+                      tags={entry.tags}
+                      onTagClick={(tag) => {
+                        const current = filters.tagIds || []
+                        if (!current.includes(tag.id)) {
+                          updateFilters({ ...filters, tagIds: [...current, tag.id] })
+                        }
+                      }}
+                    />
+                  </>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <div className="p-4 bg-surface rounded-lg border border-border space-y-4">
+            <JournalFilterBar
+              filters={filters}
+              availableTags={allTags}
+              onChange={updateFilters}
+            />
+            <div className="border-t border-border" />
+            <CalendarView
+              onDayClick={handleDayClick}
+              activeDate={activeDate}
+              filters={filters}
+              className="border-0 p-0"
+            />
+          </div>
+        </div>
+      </div>
+
+      {selectedEntry && (
+        <JournalDetailPanel
+          entry={selectedEntry}
+          onClose={() => setSelectedEntry(null)}
+          onEntryClick={(entry) => setSelectedEntry(entry)}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/vite-project/src/pages/Journal.tsx
+++ b/frontend/vite-project/src/pages/Journal.tsx
@@ -242,8 +242,25 @@ export default function JournalPage() {
     <div className="max-w-6xl mx-auto mt-6 px-3 mb-8">
       <h2 className="text-2xl font-150 mb-6">Journal</h2>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
-        <div className="lg:col-span-2 space-y-3">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-y-6 mb-6">
+        <div className="lg:col-span-2 p-4">
+          <JournalFilterBar
+            filters={filters}
+            availableTags={allTags}
+            onChange={updateFilters}
+          />
+        </div>
+
+        <div className="lg:row-span-2 lg:self-start p-4 bg-surface rounded-lg border border-border">
+          <CalendarView
+            onDayClick={handleDayClick}
+            activeDate={activeDate}
+            filters={filters}
+            className="border-0 p-0"
+          />
+        </div>
+
+        <div className="lg:col-span-2 lg:pr-6 space-y-3">
           <div className="flex justify-between items-center">
             <span className="text-sm text-muted">
               {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
@@ -309,7 +326,7 @@ export default function JournalPage() {
               <div
                 key={entry.id}
                 onClick={() => !editingEntryId && setSelectedEntry(entry)}
-                className={`p-4 bg-surface rounded-lg border border-border cursor-pointer hover:bg-surface-hover transition-colors ${getTypeBg(entry.entryType)}`}
+                className={`relative group p-4 bg-surface-hover rounded-lg border border-border cursor-pointer hover:bg-elevated transition-colors ${getTypeBg(entry.entryType)}`}
               >
                 <div className="flex justify-between items-start mb-1">
                   <div className="flex items-center gap-2">
@@ -320,31 +337,7 @@ export default function JournalPage() {
                       <span className="text-xs font-semibold text-foreground">{entry.ticker}</span>
                     )}
                   </div>
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs text-muted">{formatDateTime(entry.timestamp)}</span>
-                    {editingEntryId !== entry.id && (
-                      <>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleEditClick(entry)
-                          }}
-                          className="text-xs text-primary hover:text-primary-hover px-2 py-1 rounded hover:bg-primary/10 transition-colors"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleDelete(entry.id)
-                          }}
-                          className="text-xs text-error hover:text-error px-2 py-1 rounded hover:bg-error/10 transition-colors"
-                        >
-                          Delete
-                        </button>
-                      </>
-                    )}
-                  </div>
+                  <span className="text-xs text-muted">{formatDateTime(entry.timestamp)}</span>
                 </div>
                 {entry.priceSnapshot != null && (
                   <div className="text-xs text-muted mb-1">
@@ -357,6 +350,7 @@ export default function JournalPage() {
                       value={editBody}
                       onChange={setEditBody}
                       rows={3}
+                      className="bg-transparent text-sm text-foreground border-none focus:ring-0 resize-none"
                     />
                     <div className="flex gap-2 mt-2">
                       <button
@@ -387,27 +381,32 @@ export default function JournalPage() {
                         }
                       }}
                     />
+                    <div className="absolute bottom-2 right-2 flex gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleEditClick(entry)
+                        }}
+                        className="px-2.5 py-1 text-xs text-primary hover:text-primary-hover bg-surface border border-border rounded hover:bg-surface-hover transition-colors"
+                        title="Edit"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleDelete(entry.id)
+                        }}
+                        className="px-2.5 py-1 text-xs text-error hover:text-error bg-surface border border-border rounded hover:bg-error/10 transition-colors"
+                        title="Delete"
+                      >
+                        Delete
+                      </button>
+                    </div>
                   </>
                 )}
               </div>
             ))}
-          </div>
-        </div>
-
-        <div className="space-y-6">
-          <div className="p-4 bg-surface rounded-lg border border-border space-y-4">
-            <JournalFilterBar
-              filters={filters}
-              availableTags={allTags}
-              onChange={updateFilters}
-            />
-            <div className="border-t border-border" />
-            <CalendarView
-              onDayClick={handleDayClick}
-              activeDate={activeDate}
-              filters={filters}
-              className="border-0 p-0"
-            />
           </div>
         </div>
       </div>

--- a/frontend/vite-project/src/services/api.ts
+++ b/frontend/vite-project/src/services/api.ts
@@ -81,9 +81,11 @@ export const stockApi = {
   },
 }
 
+import type { CalendarDay, CreateJournalEntryRequest, JournalFilters, UpdateJournalEntryRequest } from '../types/journal'
+
 // Journal API
 export const journalApi = {
-  createEntry: (entry: { entryType: string; body: string; ticker?: string | null; timestamp?: string; priceSnapshot?: number }) =>
+  createEntry: (entry: CreateJournalEntryRequest) =>
     apiClient('/journal', { method: 'POST', body: entry }),
 
   getEntries: () =>
@@ -95,11 +97,49 @@ export const journalApi = {
   getEntriesInRange: (from: string, to: string) =>
     apiClient(`/journal/range?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`),
 
+  getFilteredEntries: (params: {
+    from?: string
+    to?: string
+    types?: string[]
+    ticker?: string
+    tagIds?: number[]
+    query?: string
+  }) => {
+    const searchParams = new URLSearchParams()
+    if (params.from) searchParams.set('from', params.from)
+    if (params.to) searchParams.set('to', params.to)
+    if (params.ticker) searchParams.set('ticker', params.ticker)
+    if (params.query) searchParams.set('query', params.query)
+    params.types?.forEach((t) => searchParams.append('types', t))
+    params.tagIds?.forEach((id) => searchParams.append('tagIds', id.toString()))
+    const queryString = searchParams.toString()
+    return apiClient(`/journal/filtered${queryString ? '?' + queryString : ''}`)
+  },
+
+  getCalendarEntries: (year: number, month: number, filters?: JournalFilters) => {
+    const params = new URLSearchParams()
+    params.set('year', year.toString())
+    params.set('month', month.toString())
+    if (filters?.from) params.set('from', filters.from)
+    if (filters?.to) params.set('to', filters.to)
+    if (filters?.ticker) params.set('ticker', filters.ticker)
+    if (filters?.query) params.set('query', filters.query)
+    filters?.types?.forEach((t) => params.append('types', t))
+    filters?.tagIds?.forEach((id) => params.append('tagIds', id.toString()))
+    return apiClient(`/journal/calendar?${params.toString()}`) as Promise<CalendarDay[]>
+  },
+
   deleteEntry: (id: number) =>
     apiClient(`/journal/${id}`, { method: 'DELETE' }),
 
-  updateEntry: (id: number, body: string) =>
-    apiClient(`/journal/${id}`, { method: 'PUT', body: { body } }),
+  updateEntry: (id: number, body: UpdateJournalEntryRequest) =>
+    apiClient(`/journal/${id}`, { method: 'PUT', body }),
+
+  getPopularTags: (query: string) =>
+    apiClient(`/journal/tags/popular?query=${encodeURIComponent(query)}`),
+
+  deleteTag: (id: number) =>
+    apiClient(`/journal/tags/${id}`, { method: 'DELETE' }),
 }
 
 // Watchlist API

--- a/frontend/vite-project/src/types/journal.ts
+++ b/frontend/vite-project/src/types/journal.ts
@@ -1,5 +1,11 @@
 export type JournalEntryType = 'BUY' | 'SELL' | 'INSIGHT' | 'MARKET_EVENT'
 
+export type Tag = {
+  id: number
+  name: string
+  color: string
+}
+
 export type JournalEntry = {
   id: number
   entryType: JournalEntryType
@@ -7,14 +13,33 @@ export type JournalEntry = {
   ticker: string | null
   timestamp: string
   priceSnapshot: number | null
+  tags: Tag[]
 }
 
 export type CreateJournalEntryRequest = {
   entryType: JournalEntryType
   body: string
   ticker?: string | null
+  timestamp?: string
+  priceSnapshot?: number
+  tags?: string[]
 }
 
 export type UpdateJournalEntryRequest = {
   body: string
+  tags?: string[]
+}
+
+export type CalendarDay = {
+  date: string
+  count: number
+}
+
+export type JournalFilters = {
+  from?: string
+  to?: string
+  types?: JournalEntryType[]
+  ticker?: string
+  tagIds?: number[]
+  query?: string
 }

--- a/frontend/vite-project/src/utils/chartData.test.ts
+++ b/frontend/vite-project/src/utils/chartData.test.ts
@@ -107,6 +107,7 @@ describe('processHourlyData', () => {
         ticker: 'AAPL',
         timestamp: '2026-05-21T15:17:00Z', // 11:17 AM local, within 5 min window
         priceSnapshot: 150,
+        tags: [],
       },
       {
         id: 99,
@@ -115,6 +116,7 @@ describe('processHourlyData', () => {
         ticker: 'TSLA',
         timestamp: '2026-05-21T15:15:00Z',
         priceSnapshot: 200,
+        tags: [],
       },
     ]
 

--- a/frontend/vite-project/src/utils/chartPins.test.ts
+++ b/frontend/vite-project/src/utils/chartPins.test.ts
@@ -44,6 +44,7 @@ describe('evaluateBuyPinOutcome', () => {
     ticker: 'AAPL',
     timestamp,
     priceSnapshot,
+    tags: [],
   })
 
   it('gain when next sell price is higher', () => {

--- a/frontend/vite-project/src/utils/tagUtils.ts
+++ b/frontend/vite-project/src/utils/tagUtils.ts
@@ -1,0 +1,51 @@
+export const TAG_REGEX = /#([A-Za-z][A-Za-z0-9_-]*)/g
+
+export function parseTagsFromBody(text: string): { body: string; tags: string[] } {
+  const matches = Array.from(text.matchAll(TAG_REGEX))
+  const tagNames = matches.map((m) => m[1].toLowerCase())
+  const uniqueTags = Array.from(new Set(tagNames))
+
+  let cleanBody = text.replace(TAG_REGEX, '').replace(/\s+/g, ' ').trim()
+
+  if (uniqueTags.length > 0) {
+    cleanBody += '\n\n' + uniqueTags.map((t) => `#${t}`).join(' ')
+  }
+
+  return { body: cleanBody, tags: uniqueTags }
+}
+
+export function getActiveTagQuery(text: string, cursorPosition: number): { query: string | null; startIndex: number } {
+  const textBeforeCursor = text.substring(0, cursorPosition)
+  const lastHash = textBeforeCursor.lastIndexOf('#')
+
+  if (lastHash === -1) return { query: null, startIndex: -1 }
+
+  const textAfterHash = textBeforeCursor.substring(lastHash + 1)
+  if (textAfterHash.includes(' ') || textAfterHash.includes('\n')) {
+    return { query: null, startIndex: -1 }
+  }
+
+  if (textAfterHash.length > 0 && !/^[A-Za-z]/.test(textAfterHash)) {
+    return { query: null, startIndex: -1 }
+  }
+
+  return { query: textAfterHash.toLowerCase(), startIndex: lastHash }
+}
+
+export function getDisplayBody(body: string): string {
+  const lastDoubleNewline = body.lastIndexOf('\n\n')
+  if (lastDoubleNewline === -1) return body
+
+  const afterNewline = body.substring(lastDoubleNewline + 2)
+  const parts = afterNewline.split(/\s+/)
+  if (parts.length > 0 && parts.every((part) => /^#[A-Za-z][A-Za-z0-9_-]*$/.test(part))) {
+    return body.substring(0, lastDoubleNewline).trimEnd()
+  }
+
+  return body
+}
+
+export function getTagsFromBody(body: string): string[] {
+  const matches = Array.from(body.matchAll(TAG_REGEX))
+  return Array.from(new Set(matches.map((m) => m[1].toLowerCase())))
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/controller/JournalEntryController.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/controller/JournalEntryController.java
@@ -1,11 +1,15 @@
 package com.github.fabianjim.portfoliomonitor.controller;
 
+import com.github.fabianjim.portfoliomonitor.dto.CalendarDayDTO;
+import com.github.fabianjim.portfoliomonitor.dto.CreateJournalEntryRequest;
+import com.github.fabianjim.portfoliomonitor.dto.UpdateJournalEntryRequest;
 import com.github.fabianjim.portfoliomonitor.model.DemoSession;
 import com.github.fabianjim.portfoliomonitor.model.JournalEntry;
 import com.github.fabianjim.portfoliomonitor.model.User;
 import com.github.fabianjim.portfoliomonitor.service.DemoSessionResolver;
 import com.github.fabianjim.portfoliomonitor.service.DemoSessionService;
 import com.github.fabianjim.portfoliomonitor.service.JournalEntryService;
+import com.github.fabianjim.portfoliomonitor.service.TagService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,23 +23,37 @@ public class JournalEntryController {
     private final JournalEntryService journalEntryService;
     private final DemoSessionResolver demoSessionResolver;
     private final DemoSessionService demoSessionService;
+    private final TagService tagService;
 
     public JournalEntryController(JournalEntryService journalEntryService,
                                   DemoSessionResolver demoSessionResolver,
-                                  DemoSessionService demoSessionService) {
+                                  DemoSessionService demoSessionService,
+                                  TagService tagService) {
         this.journalEntryService = journalEntryService;
         this.demoSessionResolver = demoSessionResolver;
         this.demoSessionService = demoSessionService;
+        this.tagService = tagService;
+    }
+
+    private JournalEntry buildEntryFromDto(CreateJournalEntryRequest dto) {
+        JournalEntry entry = new JournalEntry();
+        entry.setEntryType(dto.getEntryType());
+        entry.setBody(dto.getBody());
+        entry.setTicker(dto.getTicker());
+        entry.setTimestamp(dto.getTimestamp());
+        entry.setPriceSnapshot(dto.getPriceSnapshot());
+        return entry;
     }
 
     @PostMapping
-    public JournalEntry createEntry(@RequestBody JournalEntry entry, HttpServletRequest request) {
+    public JournalEntry createEntry(@RequestBody CreateJournalEntryRequest dto, HttpServletRequest request) {
+        JournalEntry entry = buildEntryFromDto(dto);
         if (demoSessionResolver.isDemoUser()) {
             DemoSession session = demoSessionResolver.resolveSession(request);
             User user = demoSessionResolver.getCurrentUser();
-            return demoSessionService.createJournalEntry(session, user, entry);
+            return demoSessionService.createJournalEntry(session, user, entry, dto.getTags());
         }
-        return journalEntryService.createEntry(entry);
+        return journalEntryService.createEntry(entry, dto.getTags());
     }
 
     @GetMapping
@@ -62,6 +80,53 @@ public class JournalEntryController {
         return journalEntryService.getEntriesInRange(from, to);
     }
 
+    @GetMapping("/filtered")
+    public List<JournalEntry> getFilteredEntries(
+            @RequestParam(required = false) Instant from,
+            @RequestParam(required = false) Instant to,
+            @RequestParam(required = false) List<String> types,
+            @RequestParam(required = false) String ticker,
+            @RequestParam(required = false) List<Integer> tagIds,
+            @RequestParam(required = false) String query,
+            HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            return demoSessionService.getFilteredJournalEntries(demoSessionResolver.resolveSession(request), from, to, types, ticker, tagIds, query);
+        }
+        return journalEntryService.getFilteredEntries(from, to, types, ticker, tagIds, query);
+    }
+
+    @GetMapping("/calendar")
+    public List<CalendarDayDTO> getCalendarEntries(
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam(required = false) Instant from,
+            @RequestParam(required = false) Instant to,
+            @RequestParam(required = false) List<String> types,
+            @RequestParam(required = false) String ticker,
+            @RequestParam(required = false) List<Integer> tagIds,
+            @RequestParam(required = false) String query,
+            HttpServletRequest request) {
+        if (demoSessionResolver.isDemoUser()) {
+            return demoSessionService.getJournalCalendarEntries(demoSessionResolver.resolveSession(request), year, month, from, to, types, ticker, tagIds, query);
+        }
+        return journalEntryService.getCalendarEntries(year, month, from, to, types, ticker, tagIds, query);
+    }
+
+    @GetMapping("/tags/popular")
+    public List<com.github.fabianjim.portfoliomonitor.model.Tag> getPopularTags(
+            @RequestParam(required = false, defaultValue = "") String query,
+            @RequestParam(required = false, defaultValue = "3") int limit,
+            HttpServletRequest request) {
+        User user = demoSessionResolver.getCurrentUser();
+        return tagService.findPopularTags(user, query, limit);
+    }
+
+    @DeleteMapping("/tags/{id}")
+    public void deleteTag(@PathVariable int id, HttpServletRequest request) {
+        User user = demoSessionResolver.getCurrentUser();
+        tagService.deleteTag(user.getId(), id);
+    }
+
     @DeleteMapping("/{id}")
     public void deleteEntry(@PathVariable int id, HttpServletRequest request) {
         if (demoSessionResolver.isDemoUser()) {
@@ -72,10 +137,12 @@ public class JournalEntryController {
     }
 
     @PutMapping("/{id}")
-    public JournalEntry updateEntry(@PathVariable int id, @RequestBody JournalEntry entry, HttpServletRequest request) {
+    public JournalEntry updateEntry(@PathVariable int id, @RequestBody UpdateJournalEntryRequest dto, HttpServletRequest request) {
         if (demoSessionResolver.isDemoUser()) {
-            return demoSessionService.updateJournalEntry(demoSessionResolver.resolveSession(request), id, entry.getBody());
+            DemoSession session = demoSessionResolver.resolveSession(request);
+            User user = demoSessionResolver.getCurrentUser();
+            return demoSessionService.updateJournalEntry(session, user, id, dto.getBody(), dto.getTags());
         }
-        return journalEntryService.updateEntry(id, entry.getBody());
+        return journalEntryService.updateEntry(id, dto.getBody(), dto.getTags());
     }
 }

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/dto/CalendarDayDTO.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/dto/CalendarDayDTO.java
@@ -1,0 +1,30 @@
+package com.github.fabianjim.portfoliomonitor.dto;
+
+public class CalendarDayDTO {
+
+    private String date;
+    private int count;
+
+    public CalendarDayDTO() {}
+
+    public CalendarDayDTO(String date, int count) {
+        this.date = date;
+        this.count = count;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/dto/CreateJournalEntryRequest.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/dto/CreateJournalEntryRequest.java
@@ -1,0 +1,64 @@
+package com.github.fabianjim.portfoliomonitor.dto;
+
+import com.github.fabianjim.portfoliomonitor.model.JournalEntryType;
+
+import java.time.Instant;
+import java.util.List;
+
+public class CreateJournalEntryRequest {
+
+    private JournalEntryType entryType;
+    private String body;
+    private String ticker;
+    private Instant timestamp;
+    private Double priceSnapshot;
+    private List<String> tags;
+
+    public JournalEntryType getEntryType() {
+        return entryType;
+    }
+
+    public void setEntryType(JournalEntryType entryType) {
+        this.entryType = entryType;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public String getTicker() {
+        return ticker;
+    }
+
+    public void setTicker(String ticker) {
+        this.ticker = ticker;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Double getPriceSnapshot() {
+        return priceSnapshot;
+    }
+
+    public void setPriceSnapshot(Double priceSnapshot) {
+        this.priceSnapshot = priceSnapshot;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/dto/UpdateJournalEntryRequest.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/dto/UpdateJournalEntryRequest.java
@@ -1,0 +1,25 @@
+package com.github.fabianjim.portfoliomonitor.dto;
+
+import java.util.List;
+
+public class UpdateJournalEntryRequest {
+
+    private String body;
+    private List<String> tags;
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/model/JournalEntry.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/model/JournalEntry.java
@@ -2,6 +2,8 @@ package com.github.fabianjim.portfoliomonitor.model;
 
 import jakarta.persistence.*;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -33,6 +35,14 @@ public class JournalEntry {
     @JoinColumn(name = "user_id", nullable = false)
     @JsonIgnore
     private User user;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+        name = "journal_entry_tags",
+        joinColumns = @JoinColumn(name = "journal_entry_id"),
+        inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private Set<Tag> tags = new HashSet<>();
 
     public JournalEntry() {}
 
@@ -90,5 +100,13 @@ public class JournalEntry {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public Set<Tag> getTags() {
+        return tags;
+    }
+
+    public void setTags(Set<Tag> tags) {
+        this.tags = tags;
     }
 }

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/model/Tag.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/model/Tag.java
@@ -1,0 +1,73 @@
+package com.github.fabianjim.portfoliomonitor.model;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "tags")
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = true)
+    private String color;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @JsonIgnore
+    private User user;
+
+    @ManyToMany(mappedBy = "tags")
+    @JsonIgnore
+    private Set<JournalEntry> entries = new HashSet<>();
+
+    public Tag() {}
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Set<JournalEntry> getEntries() {
+        return entries;
+    }
+
+    public void setEntries(Set<JournalEntry> entries) {
+        this.entries = entries;
+    }
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/repository/TagRepository.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/repository/TagRepository.java
@@ -1,0 +1,24 @@
+package com.github.fabianjim.portfoliomonitor.repository;
+
+import com.github.fabianjim.portfoliomonitor.model.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Integer> {
+
+    List<Tag> findByUserId(int userId);
+
+    Optional<Tag> findByUserIdAndName(int userId, String name);
+
+    @Query("SELECT t FROM Tag t LEFT JOIN t.entries e WHERE t.user.id = :userId AND LOWER(t.name) LIKE LOWER(CONCAT(:prefix, '%')) GROUP BY t ORDER BY COUNT(e) DESC, t.name ASC")
+    List<Tag> findTopTagsByUserAndPrefix(@Param("userId") int userId, @Param("prefix") String prefix, Pageable pageable);
+
+    long countByUserId(int userId);
+}

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionService.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionService.java
@@ -8,6 +8,7 @@ import com.github.fabianjim.portfoliomonitor.exception.UnknownTickerException;
 import com.github.fabianjim.portfoliomonitor.model.DemoSession;
 import com.github.fabianjim.portfoliomonitor.model.Holding;
 import com.github.fabianjim.portfoliomonitor.model.JournalEntry;
+import com.github.fabianjim.portfoliomonitor.model.JournalEntryType;
 import com.github.fabianjim.portfoliomonitor.model.Portfolio;
 import com.github.fabianjim.portfoliomonitor.model.Stock;
 import com.github.fabianjim.portfoliomonitor.model.Transaction;
@@ -25,9 +26,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import com.github.fabianjim.portfoliomonitor.dto.CalendarDayDTO;
+import com.github.fabianjim.portfoliomonitor.model.Tag;
 
 @Service
 public class DemoSessionService {
@@ -110,6 +118,18 @@ public class DemoSessionService {
             copy.setTimestamp(entry.getTimestamp());
             copy.setPriceSnapshot(entry.getPriceSnapshot());
             copy.setUser(user);
+
+            Set<Tag> tagCopies = new HashSet<>();
+            for (Tag tag : entry.getTags()) {
+                Tag tagCopy = new Tag();
+                tagCopy.setId(session.nextId());
+                tagCopy.setName(tag.getName());
+                tagCopy.setColor(tag.getColor());
+                tagCopy.setUser(user);
+                tagCopies.add(tagCopy);
+            }
+            copy.setTags(tagCopies);
+
             journalCopy.add(copy);
         }
         session.setJournalEntries(journalCopy);
@@ -517,7 +537,7 @@ public class DemoSessionService {
             .toList();
     }
 
-    public JournalEntry createJournalEntry(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, JournalEntry entry) {
+    public JournalEntry createJournalEntry(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, JournalEntry entry, List<String> tagNames) {
         entry.setUser(user);
         entry.setId(session.nextId());
         if (entry.getTimestamp() == null) {
@@ -532,6 +552,17 @@ public class DemoSessionService {
                 entry.setPriceSnapshot(null);
             }
         }
+
+        List<String> combinedTags = new ArrayList<>();
+        if (tagNames != null) {
+            combinedTags.addAll(tagNames);
+        }
+        String autoTag = computeAutoTagForSellEntry(session, entry);
+        if (autoTag != null && !combinedTags.contains(autoTag)) {
+            combinedTags.add(autoTag);
+        }
+
+        entry.setTags(resolveDemoTags(session, user, combinedTags));
         session.getJournalEntries().add(entry);
         return entry;
     }
@@ -554,6 +585,45 @@ public class DemoSessionService {
             .toList();
     }
 
+    public List<JournalEntry> getFilteredJournalEntries(DemoSession session, Instant from, Instant to, List<String> types, String ticker, List<Integer> tagIds, String query) {
+        return getJournalEntries(session).stream()
+            .filter(e -> from == null || !e.getTimestamp().isBefore(from))
+            .filter(e -> to == null || !e.getTimestamp().isAfter(to))
+            .filter(e -> types == null || types.isEmpty() || types.contains(e.getEntryType().name()))
+            .filter(e -> ticker == null || ticker.isBlank() || (e.getTicker() != null && e.getTicker().equalsIgnoreCase(ticker)))
+            .filter(e -> tagIds == null || tagIds.isEmpty() || e.getTags().stream().anyMatch(t -> tagIds.contains(t.getId())))
+            .filter(e -> query == null || query.isBlank() || e.getBody().toLowerCase().contains(query.toLowerCase()))
+            .collect(Collectors.toList());
+    }
+
+    public List<CalendarDayDTO> getJournalCalendarEntries(DemoSession session, int year, int month, Instant from, Instant to, List<String> types, String ticker, List<Integer> tagIds, String query) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        Instant start = yearMonth.atDay(1).atStartOfDay(ZoneId.systemDefault()).toInstant();
+        Instant end = yearMonth.atEndOfMonth().atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant();
+        List<JournalEntry> entries = getJournalEntriesInRange(session, start, end);
+
+        Map<LocalDate, Integer> counts = new HashMap<>();
+        for (JournalEntry entry : entries) {
+            if (from != null && entry.getTimestamp().isBefore(from)) continue;
+            if (to != null && entry.getTimestamp().isAfter(to)) continue;
+            if (types != null && !types.isEmpty() && !types.contains(entry.getEntryType().name())) continue;
+            if (ticker != null && !ticker.isBlank() && (entry.getTicker() == null || !entry.getTicker().equalsIgnoreCase(ticker))) continue;
+            if (tagIds != null && !tagIds.isEmpty() && entry.getTags().stream().noneMatch(t -> tagIds.contains(t.getId()))) continue;
+            if (query != null && !query.isBlank() && !entry.getBody().toLowerCase().contains(query.toLowerCase())) continue;
+
+            LocalDate date = entry.getTimestamp().atZone(ZoneId.systemDefault()).toLocalDate();
+            counts.merge(date, 1, Integer::sum);
+        }
+
+        return counts.entrySet().stream()
+            .map(e -> new CalendarDayDTO(e.getKey().toString(), e.getValue()))
+            .collect(Collectors.toList());
+    }
+
+    public List<CalendarDayDTO> getJournalCalendarEntries(DemoSession session, int year, int month) {
+        return getJournalCalendarEntries(session, year, month, null, null, null, null, null, null);
+    }
+
     public void deleteJournalEntry(DemoSession session, int id) {
         boolean removed = session.getJournalEntries().removeIf(e -> e.getId() == id);
         if (!removed) {
@@ -561,7 +631,7 @@ public class DemoSessionService {
         }
     }
 
-    public JournalEntry updateJournalEntry(DemoSession session, int id, String body) {
+    public JournalEntry updateJournalEntry(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, int id, String body, List<String> tagNames) {
         Optional<JournalEntry> entryOpt = session.getJournalEntries().stream()
             .filter(e -> e.getId() == id)
             .findFirst();
@@ -570,7 +640,97 @@ public class DemoSessionService {
         }
         JournalEntry entry = entryOpt.get();
         entry.setBody(body);
+        entry.setTags(resolveDemoTags(session, user, tagNames));
         return entry;
+    }
+
+    private Set<Tag> resolveDemoTags(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, List<String> tagNames) {
+        Set<Tag> tags = new HashSet<>();
+        if (tagNames == null) {
+            return tags;
+        }
+
+        for (String name : tagNames) {
+            String normalized = name.trim().replaceAll("^#+", "").toLowerCase();
+            if (normalized.isEmpty()) {
+                continue;
+            }
+
+            Optional<Tag> existing = session.getJournalEntries().stream()
+                .flatMap(e -> e.getTags().stream())
+                .filter(t -> t.getName().equals(normalized))
+                .findFirst();
+
+            if (existing.isPresent()) {
+                tags.add(existing.get());
+            } else {
+                Tag tag = new Tag();
+                tag.setId(session.nextId());
+                tag.setName(normalized);
+                tag.setColor(assignDemoTagColor(session));
+                tag.setUser(user);
+                tags.add(tag);
+            }
+        }
+        return tags;
+    }
+
+    private String assignDemoTagColor(DemoSession session) {
+        String[] colors = {"#5e9ed6", "#10b981", "#ef4444", "#d6965e", "#8b5cf6", "#f59e0b", "#ec4899", "#6366f1"};
+        int count = 0;
+        for (JournalEntry entry : session.getJournalEntries()) {
+            count += entry.getTags().size();
+        }
+        return colors[count % colors.length];
+    }
+
+    private String computeAutoTagForSellEntry(DemoSession session, JournalEntry entry) {
+        if (entry.getEntryType() != JournalEntryType.SELL || entry.getTicker() == null || entry.getTicker().isBlank()) {
+            return null;
+        }
+        Double realizedPnl = computeRealizedPnlForTicker(session, entry.getTicker());
+        if (realizedPnl == null) {
+            return null;
+        }
+        if (realizedPnl > 0) {
+            return "win";
+        }
+        if (realizedPnl < 0) {
+            return "loss";
+        }
+        return null;
+    }
+
+    private Double computeRealizedPnlForTicker(DemoSession session, String ticker) {
+        List<Transaction> transactions = session.getTransactions();
+        if (transactions == null || transactions.isEmpty()) {
+            return null;
+        }
+
+        double buyShares = 0;
+        double buyCost = 0;
+        double sellShares = 0;
+        double sellProceeds = 0;
+
+        for (Transaction tx : transactions) {
+            if (!ticker.equalsIgnoreCase(tx.getTicker())) {
+                continue;
+            }
+            if (tx.getType() == Transaction.TransactionType.BUY) {
+                buyShares += tx.getShares();
+                buyCost += tx.getTotalValue();
+            } else if (tx.getType() == Transaction.TransactionType.SELL) {
+                sellShares += tx.getShares();
+                sellProceeds += tx.getTotalValue();
+            }
+        }
+
+        if (buyShares == 0) {
+            return null;
+        }
+
+        double avgCost = buyCost / buyShares;
+        return sellProceeds - (avgCost * sellShares);
     }
 
     public WatchlistItem addToWatchlist(DemoSession session, com.github.fabianjim.portfoliomonitor.model.User user, String ticker) {

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/service/JournalEntryService.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/service/JournalEntryService.java
@@ -1,9 +1,13 @@
 package com.github.fabianjim.portfoliomonitor.service;
 
 import com.github.fabianjim.portfoliomonitor.model.JournalEntry;
+import com.github.fabianjim.portfoliomonitor.model.JournalEntryType;
 import com.github.fabianjim.portfoliomonitor.model.Stock;
+import com.github.fabianjim.portfoliomonitor.model.Tag;
+import com.github.fabianjim.portfoliomonitor.model.Transaction;
 import com.github.fabianjim.portfoliomonitor.model.User;
 import com.github.fabianjim.portfoliomonitor.repository.JournalEntryRepository;
+import com.github.fabianjim.portfoliomonitor.repository.TransactionRepository;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -11,8 +15,17 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.github.fabianjim.portfoliomonitor.dto.CalendarDayDTO;
 
 @Service
 @Transactional
@@ -20,10 +33,14 @@ public class JournalEntryService {
 
     private final JournalEntryRepository journalEntryRepository;
     private final StockService stockService;
+    private final TagService tagService;
+    private final TransactionRepository transactionRepository;
 
-    public JournalEntryService(JournalEntryRepository journalEntryRepository, StockService stockService) {
+    public JournalEntryService(JournalEntryRepository journalEntryRepository, StockService stockService, TagService tagService, TransactionRepository transactionRepository) {
         this.journalEntryRepository = journalEntryRepository;
         this.stockService = stockService;
+        this.tagService = tagService;
+        this.transactionRepository = transactionRepository;
     }
 
     private User getCurrentUser() {
@@ -38,12 +55,7 @@ public class JournalEntryService {
         return getCurrentUser().getId();
     }
 
-    public JournalEntry createEntry(JournalEntry entry) {
-        entry.setUser(getCurrentUser());
-        if (entry.getTimestamp() == null) {
-            entry.setTimestamp(Instant.now());
-        }
-
+    private void applyPriceSnapshot(JournalEntry entry) {
         if (entry.getPriceSnapshot() == null) {
             if (entry.getTicker() != null && !entry.getTicker().isBlank()) {
                 Optional<Stock> stockOpt = stockService.getLatestStockData(entry.getTicker());
@@ -52,8 +64,32 @@ public class JournalEntryService {
                 entry.setPriceSnapshot(null);
             }
         }
+    }
 
+    public JournalEntry createEntry(JournalEntry entry, List<String> tagNames) {
+        User user = getCurrentUser();
+        entry.setUser(user);
+        if (entry.getTimestamp() == null) {
+            entry.setTimestamp(Instant.now());
+        }
+
+        applyPriceSnapshot(entry);
+
+        List<String> combinedTags = new ArrayList<>();
+        if (tagNames != null) {
+            combinedTags.addAll(tagNames);
+        }
+        String autoTag = computeAutoTagForSellEntry(user, entry);
+        if (autoTag != null && !combinedTags.contains(autoTag)) {
+            combinedTags.add(autoTag);
+        }
+
+        entry.setTags(tagService.resolveTags(user, combinedTags));
         return journalEntryRepository.save(entry);
+    }
+
+    public JournalEntry createEntry(JournalEntry entry) {
+        return createEntry(entry, List.of());
     }
 
     public List<JournalEntry> getEntriesForUser() {
@@ -68,6 +104,46 @@ public class JournalEntryService {
         return journalEntryRepository.findByUserIdAndTimestampBetween(getCurrentUserId(), from, to);
     }
 
+    public List<JournalEntry> getFilteredEntries(Instant from, Instant to, List<String> types, String ticker, List<Integer> tagIds, String query) {
+        List<JournalEntry> entries = journalEntryRepository.findByUserIdOrderByTimestampDesc(getCurrentUserId());
+        return entries.stream()
+            .filter(e -> from == null || !e.getTimestamp().isBefore(from))
+            .filter(e -> to == null || !e.getTimestamp().isAfter(to))
+            .filter(e -> types == null || types.isEmpty() || types.contains(e.getEntryType().name()))
+            .filter(e -> ticker == null || ticker.isBlank() || (e.getTicker() != null && e.getTicker().equalsIgnoreCase(ticker)))
+            .filter(e -> tagIds == null || tagIds.isEmpty() || e.getTags().stream().anyMatch(t -> tagIds.contains(t.getId())))
+            .filter(e -> query == null || query.isBlank() || e.getBody().toLowerCase().contains(query.toLowerCase()))
+            .collect(Collectors.toList());
+    }
+
+    public List<CalendarDayDTO> getCalendarEntries(int year, int month, Instant from, Instant to, List<String> types, String ticker, List<Integer> tagIds, String query) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        Instant start = yearMonth.atDay(1).atStartOfDay(ZoneId.systemDefault()).toInstant();
+        Instant end = yearMonth.atEndOfMonth().atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant();
+        List<JournalEntry> entries = journalEntryRepository.findByUserIdAndTimestampBetween(getCurrentUserId(), start, end);
+
+        Map<LocalDate, Integer> counts = new HashMap<>();
+        for (JournalEntry entry : entries) {
+            if (from != null && entry.getTimestamp().isBefore(from)) continue;
+            if (to != null && entry.getTimestamp().isAfter(to)) continue;
+            if (types != null && !types.isEmpty() && !types.contains(entry.getEntryType().name())) continue;
+            if (ticker != null && !ticker.isBlank() && (entry.getTicker() == null || !entry.getTicker().equalsIgnoreCase(ticker))) continue;
+            if (tagIds != null && !tagIds.isEmpty() && entry.getTags().stream().noneMatch(t -> tagIds.contains(t.getId()))) continue;
+            if (query != null && !query.isBlank() && !entry.getBody().toLowerCase().contains(query.toLowerCase())) continue;
+
+            LocalDate date = entry.getTimestamp().atZone(ZoneId.systemDefault()).toLocalDate();
+            counts.merge(date, 1, Integer::sum);
+        }
+
+        return counts.entrySet().stream()
+            .map(e -> new CalendarDayDTO(e.getKey().toString(), e.getValue()))
+            .collect(Collectors.toList());
+    }
+
+    public List<CalendarDayDTO> getCalendarEntries(int year, int month) {
+        return getCalendarEntries(year, month, null, null, null, null, null, null);
+    }
+
     public void deleteEntry(int id) {
         int userId = getCurrentUserId();
         JournalEntry entry = journalEntryRepository.findById(id)
@@ -78,7 +154,7 @@ public class JournalEntryService {
         journalEntryRepository.deleteById(id);
     }
 
-    public JournalEntry updateEntry(int id, String body) {
+    public JournalEntry updateEntry(int id, String body, List<String> tagNames) {
         int userId = getCurrentUserId();
         JournalEntry entry = journalEntryRepository.findById(id)
             .orElseThrow(() -> new RuntimeException("Journal entry not found"));
@@ -86,6 +162,57 @@ public class JournalEntryService {
             throw new RuntimeException("Journal entry not found");
         }
         entry.setBody(body);
+        entry.setTags(tagService.resolveTags(getCurrentUser(), tagNames));
         return journalEntryRepository.save(entry);
+    }
+
+    public JournalEntry updateEntry(int id, String body) {
+        return updateEntry(id, body, List.of());
+    }
+
+    private String computeAutoTagForSellEntry(User user, JournalEntry entry) {
+        if (entry.getEntryType() != JournalEntryType.SELL || entry.getTicker() == null || entry.getTicker().isBlank()) {
+            return null;
+        }
+        Double realizedPnl = computeRealizedPnlForTicker(user, entry.getTicker());
+        if (realizedPnl == null) {
+            return null;
+        }
+        if (realizedPnl > 0) {
+            return "win";
+        }
+        if (realizedPnl < 0) {
+            return "loss";
+        }
+        return null;
+    }
+
+    private Double computeRealizedPnlForTicker(User user, String ticker) {
+        List<Transaction> transactions = transactionRepository.findByUserIdAndTicker(user.getId(), ticker);
+        if (transactions.isEmpty()) {
+            return null;
+        }
+
+        double buyShares = 0;
+        double buyCost = 0;
+        double sellShares = 0;
+        double sellProceeds = 0;
+
+        for (Transaction tx : transactions) {
+            if (tx.getType() == Transaction.TransactionType.BUY) {
+                buyShares += tx.getShares();
+                buyCost += tx.getTotalValue();
+            } else if (tx.getType() == Transaction.TransactionType.SELL) {
+                sellShares += tx.getShares();
+                sellProceeds += tx.getTotalValue();
+            }
+        }
+
+        if (buyShares == 0) {
+            return null;
+        }
+
+        double avgCost = buyCost / buyShares;
+        return sellProceeds - (avgCost * sellShares);
     }
 }

--- a/src/main/java/com/github/fabianjim/portfoliomonitor/service/TagService.java
+++ b/src/main/java/com/github/fabianjim/portfoliomonitor/service/TagService.java
@@ -1,0 +1,80 @@
+package com.github.fabianjim.portfoliomonitor.service;
+
+import com.github.fabianjim.portfoliomonitor.model.Tag;
+import com.github.fabianjim.portfoliomonitor.model.User;
+import com.github.fabianjim.portfoliomonitor.repository.TagRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+@Transactional
+public class TagService {
+
+    private static final String[] TAG_COLORS = {
+        "#5e9ed6", "#10b981", "#ef4444", "#d6965e", "#8b5cf6", "#f59e0b", "#ec4899", "#6366f1"
+    };
+
+    private final TagRepository tagRepository;
+
+    public TagService(TagRepository tagRepository) {
+        this.tagRepository = tagRepository;
+    }
+
+    public List<Tag> findPopularTags(User user, String prefix, int limit) {
+        String query = prefix == null ? "" : prefix;
+        return tagRepository.findTopTagsByUserAndPrefix(user.getId(), query.toLowerCase(), PageRequest.of(0, limit));
+    }
+
+    public Set<Tag> resolveTags(User user, List<String> tagNames) {
+        Set<Tag> tags = new HashSet<>();
+        if (tagNames == null) {
+            return tags;
+        }
+
+        for (String name : tagNames) {
+            String normalized = normalizeTagName(name);
+            if (normalized.isEmpty()) {
+                continue;
+            }
+
+            Optional<Tag> existing = tagRepository.findByUserIdAndName(user.getId(), normalized);
+            if (existing.isPresent()) {
+                tags.add(existing.get());
+            } else {
+                Tag tag = new Tag();
+                tag.setName(normalized);
+                tag.setColor(assignColor(user));
+                tag.setUser(user);
+                tags.add(tagRepository.save(tag));
+            }
+        }
+        return tags;
+    }
+
+    public void deleteTag(int userId, int tagId) {
+        Tag tag = tagRepository.findById(tagId)
+            .orElseThrow(() -> new RuntimeException("Tag not found"));
+        if (tag.getUser().getId() != userId) {
+            throw new RuntimeException("Tag not found");
+        }
+        tagRepository.delete(tag);
+    }
+
+    private String assignColor(User user) {
+        long count = tagRepository.countByUserId(user.getId());
+        return TAG_COLORS[(int) (count % TAG_COLORS.length)];
+    }
+
+    private String normalizeTagName(String name) {
+        if (name == null) {
+            return "";
+        }
+        return name.trim().replaceAll("^#+", "").toLowerCase();
+    }
+}

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/controller/JournalEntryControllerTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/controller/JournalEntryControllerTest.java
@@ -7,6 +7,7 @@ import com.github.fabianjim.portfoliomonitor.model.User;
 import com.github.fabianjim.portfoliomonitor.service.DemoSessionResolver;
 import com.github.fabianjim.portfoliomonitor.service.DemoSessionService;
 import com.github.fabianjim.portfoliomonitor.service.JournalEntryService;
+import com.github.fabianjim.portfoliomonitor.service.TagService;
 import com.github.fabianjim.portfoliomonitor.service.UserService;
 
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -48,6 +50,9 @@ public class JournalEntryControllerTest {
     @MockitoBean
     private UserService userService;
 
+    @MockitoBean
+    private TagService tagService;
+
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -67,7 +72,7 @@ public class JournalEntryControllerTest {
         entry.setPriceSnapshot(150.0);
         entry.setUser(user);
 
-        when(journalEntryService.createEntry(any(JournalEntry.class))).thenReturn(entry);
+        when(journalEntryService.createEntry(any(JournalEntry.class), any())).thenReturn(entry);
 
         mockMvc.perform(post("/api/journal")
                 .with(csrf())
@@ -135,7 +140,7 @@ public class JournalEntryControllerTest {
         entry.setTimestamp(Instant.now());
         entry.setUser(user);
 
-        when(journalEntryService.updateEntry(1, "Updated insight")).thenReturn(entry);
+        when(journalEntryService.updateEntry(eq(1), eq("Updated insight"), any())).thenReturn(entry);
 
         JournalEntry updateRequest = new JournalEntry();
         updateRequest.setBody("Updated insight");

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionServiceTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/service/DemoSessionServiceTest.java
@@ -203,14 +203,14 @@ public class DemoSessionServiceTest {
 
         when(stockService.getLatestStockData("AAPL")).thenReturn(Optional.empty());
 
-        JournalEntry created = demoSessionService.createJournalEntry(session, demoUser, entry);
+        JournalEntry created = demoSessionService.createJournalEntry(session, demoUser, entry, List.of());
         assertTrue(created.getId() < 0);
         assertEquals(demoUser, created.getUser());
 
         List<JournalEntry> entries = demoSessionService.getJournalEntries(session);
         assertEquals(1, entries.size());
 
-        JournalEntry updated = demoSessionService.updateJournalEntry(session, created.getId(), "Updated");
+        JournalEntry updated = demoSessionService.updateJournalEntry(session, demoUser, created.getId(), "Updated", List.of());
         assertEquals("Updated", updated.getBody());
 
         demoSessionService.deleteJournalEntry(session, created.getId());

--- a/src/test/java/com/github/fabianjim/portfoliomonitor/service/JournalEntryServiceTest.java
+++ b/src/test/java/com/github/fabianjim/portfoliomonitor/service/JournalEntryServiceTest.java
@@ -3,8 +3,11 @@ package com.github.fabianjim.portfoliomonitor.service;
 import com.github.fabianjim.portfoliomonitor.model.JournalEntry;
 import com.github.fabianjim.portfoliomonitor.model.JournalEntryType;
 import com.github.fabianjim.portfoliomonitor.model.Stock;
+import com.github.fabianjim.portfoliomonitor.model.Tag;
+import com.github.fabianjim.portfoliomonitor.model.Transaction;
 import com.github.fabianjim.portfoliomonitor.model.User;
 import com.github.fabianjim.portfoliomonitor.repository.JournalEntryRepository;
+import com.github.fabianjim.portfoliomonitor.repository.TransactionRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,8 +22,10 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,6 +39,12 @@ public class JournalEntryServiceTest {
 
     @Mock
     private StockService stockService;
+
+    @Mock
+    private TagService tagService;
+
+    @Mock
+    private TransactionRepository transactionRepository;
 
     @Mock
     private SecurityContext securityContext;
@@ -55,6 +66,7 @@ public class JournalEntryServiceTest {
         SecurityContextHolder.setContext(securityContext);
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(authentication.getPrincipal()).thenReturn(mockUser);
+        lenient().when(tagService.resolveTags(any(User.class), any())).thenReturn(new HashSet<>());
     }
 
     @Test
@@ -128,6 +140,92 @@ public class JournalEntryServiceTest {
         JournalEntry result = journalEntryService.createEntry(entry);
 
         assertEquals(0.0, result.getPriceSnapshot(), 0.01);
+    }
+
+    @Test
+    void createSellEntryWithProfitAddsWinTag() {
+        String ticker = "AAPL";
+        when(journalEntryRepository.save(any(JournalEntry.class))).thenAnswer(invocation -> {
+            JournalEntry e = invocation.getArgument(0);
+            e.setId(1);
+            return e;
+        });
+        when(transactionRepository.findByUserIdAndTicker(mockUser.getId(), ticker))
+            .thenReturn(List.of(
+                createTransaction(ticker, 10, 100.0, Transaction.TransactionType.BUY),
+                createTransaction(ticker, 5, 120.0, Transaction.TransactionType.SELL)
+            ));
+
+        JournalEntry entry = new JournalEntry();
+        entry.setEntryType(JournalEntryType.SELL);
+        entry.setBody("Sold AAPL");
+        entry.setTicker(ticker);
+        entry.setPriceSnapshot(120.0);
+
+        journalEntryService.createEntry(entry);
+
+        ArgumentCaptor<List<String>> tagCaptor = ArgumentCaptor.forClass(List.class);
+        verify(tagService).resolveTags(eq(mockUser), tagCaptor.capture());
+        assertTrue(tagCaptor.getValue().contains("win"));
+    }
+
+    @Test
+    void createSellEntryWithLossAddsLossTag() {
+        String ticker = "AAPL";
+        when(journalEntryRepository.save(any(JournalEntry.class))).thenAnswer(invocation -> {
+            JournalEntry e = invocation.getArgument(0);
+            e.setId(1);
+            return e;
+        });
+        when(transactionRepository.findByUserIdAndTicker(mockUser.getId(), ticker))
+            .thenReturn(List.of(
+                createTransaction(ticker, 10, 100.0, Transaction.TransactionType.BUY),
+                createTransaction(ticker, 5, 80.0, Transaction.TransactionType.SELL)
+            ));
+
+        JournalEntry entry = new JournalEntry();
+        entry.setEntryType(JournalEntryType.SELL);
+        entry.setBody("Sold AAPL");
+        entry.setTicker(ticker);
+        entry.setPriceSnapshot(80.0);
+
+        journalEntryService.createEntry(entry);
+
+        ArgumentCaptor<List<String>> tagCaptor = ArgumentCaptor.forClass(List.class);
+        verify(tagService).resolveTags(eq(mockUser), tagCaptor.capture());
+        assertTrue(tagCaptor.getValue().contains("loss"));
+    }
+
+    @Test
+    void createSellEntryWithNoTransactionsDoesNotAddAutoTag() {
+        String ticker = "AAPL";
+        when(journalEntryRepository.save(any(JournalEntry.class))).thenAnswer(invocation -> {
+            JournalEntry e = invocation.getArgument(0);
+            e.setId(1);
+            return e;
+        });
+        when(transactionRepository.findByUserIdAndTicker(mockUser.getId(), ticker))
+            .thenReturn(List.of());
+
+        JournalEntry entry = new JournalEntry();
+        entry.setEntryType(JournalEntryType.SELL);
+        entry.setBody("Sold AAPL");
+        entry.setTicker(ticker);
+        entry.setPriceSnapshot(120.0);
+
+        journalEntryService.createEntry(entry);
+
+        ArgumentCaptor<List<String>> tagCaptor = ArgumentCaptor.forClass(List.class);
+        verify(tagService).resolveTags(eq(mockUser), tagCaptor.capture());
+        assertFalse(tagCaptor.getValue().contains("win"));
+        assertFalse(tagCaptor.getValue().contains("loss"));
+    }
+
+    private Transaction createTransaction(String ticker, double shares, double price, Transaction.TransactionType type) {
+        Transaction tx = new Transaction(ticker, shares, price, type);
+        tx.setTotalValue(shares * price);
+        tx.setUser(mockUser);
+        return tx;
     }
 
     @Test


### PR DESCRIPTION
- Add Journal. Includes more detailed journal entries, searching and filtering.
- Add tagging. Users can tag using '#tag' and the tag will be automatically generated. This contains an initial autocomplete tagging feature for '#win' and '#loss' as well as the most common previously used tags. 
- Add custom calendar with quantity of daily entries that can be used alongside filtering.